### PR TITLE
Fix services regressions: batch id fallback, DM v1 payload, and streaming media uploads

### DIFF
--- a/src/oopz_api.py
+++ b/src/oopz_api.py
@@ -768,9 +768,9 @@ class OopzApiMixin:
                 if not data.get("status"):
                     continue
                 for person in data.get("data", []):
-                    uid = person.get("uid", "")
+                    uid = person.get("uid") or person.get("id") or ""
                     if uid:
-                        result_map[uid] = person
+                        result_map[str(uid)] = person
             except Exception as e:
                 logger.debug(f"批量获取用户信息部分失败: {e}")
         return result_map

--- a/src/oopz_sender.py
+++ b/src/oopz_sender.py
@@ -451,6 +451,7 @@ class OopzSender(UploadMixin, OopzApiMixin):
         attachments: Optional[list] = None,
         style_tags: Optional[list] = None,
         channel: Optional[str] = None,
+        version: str = "v2",
     ) -> dict:
         """
         发送私信消息。
@@ -471,26 +472,25 @@ class OopzSender(UploadMixin, OopzApiMixin):
             logger.error("发送私信失败：私信 channel 不可用 (target=%s)", target[:12])
             return {"error": "私信 channel 不可用", "debug_reason": "missing_channel"}
 
-        # Web 端格式：请求体为 { "message": { ... } }，正文用 content（Playwright 抓包确认）
-        body = {
-            "message": {
-                "area": "",
-                "channel": channel,
-                "target": target,
-                "clientMessageId": self.signer.client_message_id(),
-                "timestamp": self.signer.timestamp_us(),
-                "isMentionAll": False,
-                "mentionList": [],
-                "styleTags": style_tags if style_tags is not None else [],
-                "referenceMessageId": None,
-                "animated": False,
-                "displayName": "",
-                "duration": 0,
-                "content": text,
-                "attachments": attachments or [],
-            }
+        normalized_version = "v1" if str(version).strip().lower() == "v1" else "v2"
+        message = {
+            "area": "",
+            "channel": channel,
+            "target": target,
+            "clientMessageId": self.signer.client_message_id(),
+            "timestamp": self.signer.timestamp_us(),
+            "isMentionAll": False,
+            "mentionList": [],
+            "styleTags": style_tags if style_tags is not None else [],
+            "referenceMessageId": None,
+            "animated": False,
+            "displayName": "",
+            "duration": 0,
+            "content": text,
+            "attachments": attachments or [],
         }
-        url_path = "/im/session/v2/sendImMessage"
+        body = message if normalized_version == "v1" else {"message": message}
+        url_path = f"/im/session/{normalized_version}/sendImMessage"
 
         try:
             self._throttle()

--- a/src/oopz_upload.py
+++ b/src/oopz_upload.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import hashlib
-import io
 import os
+import tempfile
 from typing import TYPE_CHECKING, Optional
 
 import requests
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 logger = get_logger("OopzUpload")
 
 UPLOAD_PUT_TIMEOUT = (10, 60)
+DOWNLOAD_TIMEOUT = (10, 30)
+STREAM_CHUNK_SIZE = 64 * 1024
 
 
 def get_image_info(file_path: str) -> tuple[int, int, int]:
@@ -31,6 +33,66 @@ def get_image_info(file_path: str) -> tuple[int, int, int]:
 
 class UploadMixin:
     """Oopz 文件上传 Mixin — 图片、音频上传与发送。"""
+
+    @staticmethod
+    def _pick_audio_ext(content_type: str) -> str:
+        if "mp4" in content_type or "m4a" in content_type:
+            return ".m4a"
+        if "flac" in content_type:
+            return ".flac"
+        return ".mp3"
+
+    def _request_signed_upload(self, *, file_type: str, ext: str) -> dict:
+        resp = self._put("/rtc/v1/cos/v1/signedUploadUrl", {"type": file_type, "ext": ext})
+        resp.raise_for_status()
+        data = resp.json().get("data") or {}
+        signed_url = data.get("signedUrl")
+        file_key = data.get("file")
+        cdn_url = data.get("url")
+        if not signed_url or not file_key or not cdn_url:
+            raise ValueError("签名上传地址响应缺少必要字段")
+        return {"signed_url": signed_url, "file_key": file_key, "cdn_url": cdn_url}
+
+    def _download_to_spooled_file(
+        self,
+        url: str,
+        *,
+        timeout: int | tuple[int, int],
+        headers: Optional[dict] = None,
+        stream: bool = False,
+    ) -> dict:
+        with self.session.get(url, stream=stream, timeout=timeout, headers=headers) as resp:
+            resp.raise_for_status()
+            content_type = resp.headers.get("Content-Type", "")
+
+            if not stream:
+                raw = resp.content
+                fp = tempfile.SpooledTemporaryFile(max_size=2 * 1024 * 1024)
+                fp.write(raw)
+                fp.seek(0)
+                return {
+                    "file": fp,
+                    "size": len(raw),
+                    "md5": hashlib.md5(raw).hexdigest(),
+                    "content_type": content_type,
+                }
+
+            fp = tempfile.SpooledTemporaryFile(max_size=2 * 1024 * 1024)
+            digest = hashlib.md5()
+            size = 0
+            for chunk in resp.iter_content(chunk_size=STREAM_CHUNK_SIZE):
+                if not chunk:
+                    continue
+                fp.write(chunk)
+                digest.update(chunk)
+                size += len(chunk)
+            fp.seek(0)
+            return {
+                "file": fp,
+                "size": size,
+                "md5": digest.hexdigest(),
+                "content_type": content_type,
+            }
 
     def upload_file(self, file_path: str, file_type: str = "IMAGE", ext: str = ".webp") -> dict:
         """上传本地文件，返回 { fileKey, url }"""
@@ -58,44 +120,35 @@ class UploadMixin:
 
         return {"fileKey": file_key, "url": cdn_url}
 
-    def upload_file_from_url(self, image_url: str) -> dict:
+    def upload_file_from_url(self, image_url: str, *, stream: bool = False) -> dict:
         """从网络 URL 下载图片并上传到 Oopz（不落地磁盘）"""
         try:
-            resp = self.session.get(image_url, stream=True, timeout=15)
-            resp.raise_for_status()
-            image_bytes = resp.content
+            downloaded = self._download_to_spooled_file(
+                image_url, timeout=DOWNLOAD_TIMEOUT, stream=stream
+            )
+            fp = downloaded["file"]
+            with Image.open(fp) as img:
+                width, height = img.size
+                ext = "." + (img.format or "webp").lower()
 
-            img = Image.open(io.BytesIO(image_bytes))
-            width, height = img.size
-            file_size = len(image_bytes)
-            ext = "." + (img.format or "webp").lower()
-            md5 = hashlib.md5(image_bytes).hexdigest()
-
-            url_path = "/rtc/v1/cos/v1/signedUploadUrl"
-            body = {"type": "IMAGE", "ext": ext}
-            resp2 = self._put(url_path, body)
-            resp2.raise_for_status()
-            data = resp2.json()["data"]
-
-            signed_url = data["signedUrl"]
-            file_key = data["file"]
-            cdn_url = data["url"]
-
+            upload_target = self._request_signed_upload(file_type="IMAGE", ext=ext)
+            fp.seek(0)
             put_resp = self.session.put(
-                signed_url,
-                data=image_bytes,
+                upload_target["signed_url"],
+                data=fp,
                 headers={"Content-Type": "application/octet-stream"},
                 timeout=UPLOAD_PUT_TIMEOUT,
             )
             put_resp.raise_for_status()
+            fp.close()
 
             attachment = {
-                "fileKey": file_key,
-                "url": cdn_url,
+                "fileKey": upload_target["file_key"],
+                "url": upload_target["cdn_url"],
                 "width": width,
                 "height": height,
-                "fileSize": file_size,
-                "hash": md5,
+                "fileSize": downloaded["size"],
+                "hash": downloaded["md5"],
                 "animated": False,
                 "displayName": "",
                 "attachmentType": "IMAGE",
@@ -107,54 +160,42 @@ class UploadMixin:
             return {"code": "error", "message": str(e), "data": None}
 
     def upload_audio_from_url(
-        self, audio_url: str, filename: str = "music.mp3", duration_ms: int = 0
+        self,
+        audio_url: str,
+        filename: str = "music.mp3",
+        duration_ms: int = 0,
+        *,
+        stream: bool = False,
     ) -> dict:
         """从网络 URL 下载音频并上传到 Oopz（AUDIO 类型）"""
         try:
-            resp = self.session.get(audio_url, timeout=30, headers={
-                "Referer": "https://music.163.com/",
-            })
-            resp.raise_for_status()
-            audio_bytes = resp.content
-            file_size = len(audio_bytes)
-
-            content_type = resp.headers.get("Content-Type", "")
-            if "mp4" in content_type or "m4a" in content_type:
-                ext = ".m4a"
-            elif "flac" in content_type:
-                ext = ".flac"
-            else:
-                ext = ".mp3"
-
-            md5 = hashlib.md5(audio_bytes).hexdigest()
-
-            url_path = "/rtc/v1/cos/v1/signedUploadUrl"
-            body = {"type": "AUDIO", "ext": ext}
-            resp2 = self._put(url_path, body)
-            resp2.raise_for_status()
-            data = resp2.json()["data"]
-
-            signed_url = data["signedUrl"]
-            file_key = data["file"]
-            cdn_url = data["url"]
-
+            downloaded = self._download_to_spooled_file(
+                audio_url,
+                timeout=30,
+                headers={"Referer": "https://music.163.com/"},
+                stream=stream,
+            )
+            ext = self._pick_audio_ext(downloaded["content_type"])
+            upload_target = self._request_signed_upload(file_type="AUDIO", ext=ext)
+            downloaded["file"].seek(0)
             put_resp = self.session.put(
-                signed_url,
-                data=audio_bytes,
+                upload_target["signed_url"],
+                data=downloaded["file"],
                 headers={"Content-Type": "application/octet-stream"},
                 timeout=UPLOAD_PUT_TIMEOUT,
             )
             put_resp.raise_for_status()
+            downloaded["file"].close()
 
             base_name = os.path.splitext(filename or "")[0] or "music"
             display_name = base_name + ext
             duration_sec = duration_ms // 1000 if duration_ms else 0
 
             attachment = {
-                "fileKey": file_key,
-                "url": cdn_url,
-                "fileSize": file_size,
-                "hash": md5,
+                "fileKey": upload_target["file_key"],
+                "url": upload_target["cdn_url"],
+                "fileSize": downloaded["size"],
+                "hash": downloaded["md5"],
                 "animated": False,
                 "displayName": display_name,
                 "attachmentType": "AUDIO",

--- a/tests/test_services_regressions.py
+++ b/tests/test_services_regressions.py
@@ -1,0 +1,172 @@
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+import types
+
+from PIL import Image
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+if "config" not in sys.modules:
+    config_module = types.ModuleType("config")
+    config_module.DEFAULT_HEADERS = {}
+    config_module.AUTO_RECALL_CONFIG = {"enabled": False}
+    config_module.OOPZ_CONFIG = {
+        "base_url": "https://api.example.com",
+        "app_version": "test",
+        "channel": "test",
+        "device_id": "device",
+        "platform": "web",
+        "web": True,
+        "person_uid": "bot",
+        "jwt_token": "jwt",
+        "default_area": "area",
+        "default_channel": "channel",
+        "use_announcement_style": False,
+    }
+    sys.modules["config"] = config_module
+
+
+class _FakeStreamingResponse:
+    def __init__(self, *, content: bytes, headers: dict[str, str] | None = None, chunks: int = 2):
+        self.content = content
+        self.headers = headers or {}
+        self.status_code = 200
+        self._chunks = chunks
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int = 65536):
+        if self._chunks <= 1:
+            yield self.content
+            return
+        step = max(1, len(self.content) // self._chunks)
+        for i in range(0, len(self.content), step):
+            yield self.content[i : i + step]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class ServiceRegressionTest(unittest.TestCase):
+    def test_get_person_infos_batch_accepts_id_field(self) -> None:
+        from oopz_api import OopzApiMixin
+
+        api = object.__new__(OopzApiMixin)
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {
+            "status": True,
+            "data": [{"id": "u1", "name": "Alice"}],
+        }
+        api._post = Mock(return_value=response)
+
+        result = api.get_person_infos_batch(["u1"])
+
+        self.assertEqual(result["u1"]["name"], "Alice")
+
+    def test_send_private_message_v1_uses_flat_payload(self) -> None:
+        from oopz_sender import OopzSender
+
+        sender = object.__new__(OopzSender)
+        sender.signer = SimpleNamespace(
+            client_message_id=lambda: "cid",
+            timestamp_us=lambda: "ts",
+            oopz_headers=lambda url_path, body_str: {},
+        )
+        sender.session = SimpleNamespace(headers={}, post=Mock())
+        sender._throttle = Mock()
+        sender.open_private_session = Mock(return_value={"status": True, "channel": "ch-1"})
+
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.text = '{"status":true}'
+        post_response.json.return_value = {"status": True}
+        sender.session.post.return_value = post_response
+
+        result = sender.send_private_message("u1", "hello", version="v1")
+
+        self.assertTrue(result["status"])
+        post_call = sender.session.post.call_args
+        self.assertIn("/im/session/v1/sendImMessage", post_call.args[0])
+        payload = json.loads(post_call.kwargs["data"].decode("utf-8"))
+        self.assertEqual(payload["content"], "hello")
+        self.assertNotIn("message", payload)
+
+    def test_send_private_message_v2_keeps_message_wrapper(self) -> None:
+        from oopz_sender import OopzSender
+
+        sender = object.__new__(OopzSender)
+        sender.signer = SimpleNamespace(
+            client_message_id=lambda: "cid",
+            timestamp_us=lambda: "ts",
+            oopz_headers=lambda url_path, body_str: {},
+        )
+        sender.session = SimpleNamespace(headers={}, post=Mock())
+        sender._throttle = Mock()
+        sender.open_private_session = Mock(return_value={"status": True, "channel": "ch-1"})
+
+        post_response = Mock()
+        post_response.status_code = 200
+        post_response.text = '{"status":true}'
+        post_response.json.return_value = {"status": True}
+        sender.session.post.return_value = post_response
+
+        sender.send_private_message("u1", "hello")
+
+        post_call = sender.session.post.call_args
+        self.assertIn("/im/session/v2/sendImMessage", post_call.args[0])
+        payload = json.loads(post_call.kwargs["data"].decode("utf-8"))
+        self.assertIn("message", payload)
+        self.assertEqual(payload["message"]["content"], "hello")
+
+    def test_upload_file_from_url_stream_true_uses_streaming_download(self) -> None:
+        from oopz_upload import UploadMixin
+
+        image = Image.new("RGB", (3, 2), color=(255, 0, 0))
+        image_buf = io.BytesIO()
+        image.save(image_buf, format="PNG")
+        image_bytes = image_buf.getvalue()
+
+        mixin = object.__new__(UploadMixin)
+        mixin.session = SimpleNamespace(get=Mock(), put=Mock())
+        mixin._put = Mock()
+        mixin.session.get.return_value = _FakeStreamingResponse(
+            content=image_bytes,
+            headers={"Content-Type": "image/png"},
+        )
+
+        signed_resp = Mock()
+        signed_resp.raise_for_status = Mock()
+        signed_resp.json.return_value = {
+            "data": {"signedUrl": "https://upload", "file": "file-key", "url": "https://cdn/file-key"}
+        }
+        mixin._put.return_value = signed_resp
+
+        upload_resp = Mock()
+        upload_resp.raise_for_status = Mock()
+        mixin.session.put.return_value = upload_resp
+
+        result = mixin.upload_file_from_url("https://example.com/demo.png", stream=True)
+
+        self.assertEqual(result["code"], "success")
+        mixin.session.get.assert_called_once()
+        self.assertTrue(mixin.session.get.call_args.kwargs["stream"])
+        self.assertEqual(result["data"]["fileSize"], len(image_bytes))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent silently dropped user records when API returns `id` instead of `uid` and restore backward-compatible support for the old private-message endpoint and payload format.
- Reduce memory usage and duplicate logic when downloading external media and make `stream` behavior effective for large files.

### Description
- Updated `get_person_infos_batch()` to accept `person.get("uid")` or fallback to `person.get("id")`, and store keys as strings (`str(uid)`), preventing valid users from being dropped.
- Extended `send_private_message()` with a `version` parameter (default `"v2"`) and made it switch both the endpoint path and payload shape together (`v1` uses a flat message body, `v2` keeps the `{"message": ...}` wrapper).
- Refactored upload/download flows in `UploadMixin`: added `_request_signed_upload()` and `_download_to_spooled_file()` helpers, introduced `DOWNLOAD_TIMEOUT` and `STREAM_CHUNK_SIZE`, and changed `upload_file_from_url()` / `upload_audio_from_url()` to accept `stream` and use `SpooledTemporaryFile` with incremental MD5/size computation to avoid full in-memory reads.
- Added regression tests in `tests/test_services_regressions.py` covering the `id` fallback, `send_private_message` `v1`/`v2` behavior, and streaming image-download path.

### Testing
- Added `tests/test_services_regressions.py` with unit tests exercising the three regressions.
- Ran `pytest -q tests/test_services_regressions.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53142033083318ae30d299f0abd2d)