### PR TITLE
feat: 补充bili与ncm平台扫码登录;修复带cookie时的播放链路问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cryptography>=42,<48
 websocket-client>=1.8,<2
 python-socks>=2.5,<3
 pillow>=10,<13
+qrcode[pil]>=7.4,<9
 redis>=5.0,<8
 fastapi>=0.110,<1
 uvicorn[standard]>=0.30,<1

--- a/src/admin_assets/admin-shell.css
+++ b/src/admin_assets/admin-shell.css
@@ -1129,6 +1129,80 @@ select.select--compact {
   flex: 1 1 auto;
 }
 
+.netease-login,
+.qr-login {
+  display: grid;
+  gap: 10px;
+}
+
+.netease-login__body,
+.qr-login__body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+}
+
+.netease-login__meta,
+.qr-login__meta {
+  display: grid;
+  gap: 8px;
+  min-width: min(260px, 100%);
+}
+
+.netease-login__meta .section-copy,
+.qr-login__meta .section-copy {
+  margin: 0;
+  min-height: 20px;
+}
+
+.netease-account-panel,
+.account-panel {
+  min-height: 42px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ink-faint);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.6;
+}
+
+.netease-qr-box,
+.qr-box {
+  display: grid;
+  place-items: center;
+  width: 184px;
+  height: 184px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--ink-muted);
+  overflow: hidden;
+}
+
+.netease-qr-box img,
+.qr-box img {
+  width: 168px;
+  height: 168px;
+  padding: 8px;
+  border-radius: 8px;
+  background: #fff;
+  object-fit: contain;
+}
+
+.text-link {
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.text-link:hover {
+  color: var(--accent-strong);
+}
+
 /* Modal Dialog */
 .m-modal-overlay {
   position: fixed;

--- a/src/admin_assets/pages/config_content.html
+++ b/src/admin_assets/pages/config_content.html
@@ -163,11 +163,33 @@
                 <div class="field field--wide"><label for="cfg_oopz_proxy">OOPZ 代理</label><input id="cfg_oopz_proxy" type="text" placeholder="direct / http://127.0.0.1:7890" /></div>
                 <div class="field field--wide field--check"><label><input id="cfg_oopz_announcement" type="checkbox" /> 使用公告样式消息</label></div>
                 <div class="field field--wide"><label for="cfg_netease_base_url">网易云 API 地址</label><input id="cfg_netease_base_url" type="text" placeholder="http://127.0.0.1:3000" /></div>
+                <div class="field field--wide">
+                  <label>网易云扫码登录</label>
+                  <div class="netease-login">
+                    <div class="action-row">
+                      <button id="cfg_netease_qr_refresh" class="btn btn-sm btn-primary" type="button" onclick="refreshNeteaseQr()">刷新二维码</button>
+                      <button id="cfg_netease_qr_save_persist" class="btn btn-sm btn-ghost" type="button" onclick="saveNeteaseQrCookie(true)" disabled>保存并持久化</button>
+                      <button id="cfg_netease_qr_save_runtime" class="btn btn-sm btn-ghost" type="button" onclick="saveNeteaseQrCookie(false)" disabled>仅当前进程生效</button>
+                    </div>
+                    <div class="netease-login__body">
+                      <div id="cfg_netease_qr_box" class="netease-qr-box">
+                        <img id="cfg_netease_qr_img" alt="网易云扫码登录二维码" hidden />
+                        <span id="cfg_netease_qr_empty">等待刷新</span>
+                      </div>
+                      <div class="netease-login__meta">
+                        <p id="cfg_netease_qr_status" class="section-copy">未开始</p>
+                        <p id="cfg_netease_account_status" class="section-copy" data-netease-account-status>当前账号：未检测</p>
+                        <a id="cfg_netease_qr_link" class="text-link" href="#" target="_blank" rel="noopener" hidden>打开二维码链接</a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
                 <div class="field"><label for="cfg_netease_timeout">网易云音频超时（秒）</label><input id="cfg_netease_timeout" type="number" min="5" /></div>
                 <div class="field"><label for="cfg_netease_retries">网易云音频重试次数</label><input id="cfg_netease_retries" type="number" min="0" /></div>
                 <div class="field"><label for="cfg_netease_quality">网易云音质</label><input id="cfg_netease_quality" type="text" placeholder="standard / exhigh" /></div>
                 <div class="field field--wide">
                   <label for="cfg_netease_cookie">网易云 Cookie</label>
+                  <div class="netease-account-panel" data-netease-account-status>当前网易云账号：未检测</div>
                   <div class="secret-input">
                     <input id="cfg_netease_cookie" type="password" placeholder="留空表示不修改" />
                     <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_netease_cookie', this)">显示</button>
@@ -224,7 +246,28 @@
               <div class="field-grid">
                 <div class="field field--check"><label><input id="cfg_bilibili_enabled" type="checkbox" /> 启用 B 站音乐</label></div>
                 <div class="field field--wide">
+                  <label>B 站扫码登录</label>
+                  <div class="qr-login">
+                    <div class="action-row">
+                      <button id="cfg_bilibili_qr_refresh" class="btn btn-sm btn-primary" type="button" onclick="refreshBilibiliQr()">刷新二维码</button>
+                      <button id="cfg_bilibili_qr_save_persist" class="btn btn-sm btn-ghost" type="button" onclick="saveBilibiliQrCookie(true)" disabled>保存并持久化</button>
+                      <button id="cfg_bilibili_qr_save_runtime" class="btn btn-sm btn-ghost" type="button" onclick="saveBilibiliQrCookie(false)" disabled>仅当前进程生效</button>
+                    </div>
+                    <div class="qr-login__body">
+                      <div id="cfg_bilibili_qr_box" class="qr-box">
+                        <img id="cfg_bilibili_qr_img" alt="B 站扫码登录二维码" hidden />
+                        <span id="cfg_bilibili_qr_empty">等待刷新</span>
+                      </div>
+                      <div class="qr-login__meta">
+                        <p id="cfg_bilibili_qr_status" class="section-copy">未开始</p>
+                        <a id="cfg_bilibili_qr_link" class="text-link" href="#" target="_blank" rel="noopener" hidden>打开二维码链接</a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="field field--wide">
                   <label for="cfg_bilibili_cookie">Cookie</label>
+                  <div id="cfg_bilibili_account_status" class="account-panel" data-bilibili-account-status>当前B站账号：未检测</div>
                   <div class="secret-input">
                     <input id="cfg_bilibili_cookie" type="password" placeholder="留空表示不修改" />
                     <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_bilibili_cookie', this)">显示</button>

--- a/src/admin_assets/pages/config_script.js
+++ b/src/admin_assets/pages/config_script.js
@@ -83,6 +83,420 @@
       hint.textContent = "当前音乐域：" + area + "；来源：" + sourceText + "；活跃域：" + activeArea + "；默认域：" + defaultArea;
     }
 
+    let neteaseQrTimer = null;
+    let neteaseQrKey = "";
+    let neteaseQrBaseUrl = "";
+
+    function setNeteaseQrStatus(text, isError) {
+      const element = AdminShell.byId("cfg_netease_qr_status");
+      if (!element) {
+        return;
+      }
+      element.textContent = text || "";
+      element.style.color = isError ? "var(--danger)" : "var(--ink-faint)";
+    }
+
+    function renderNeteaseAccount(profile, message, isError) {
+      const targets = Array.from(document.querySelectorAll("[data-netease-account-status]"));
+      const legacy = AdminShell.byId("cfg_netease_account_status");
+      if (legacy && !targets.includes(legacy)) {
+        targets.push(legacy);
+      }
+      if (!targets.length) return;
+      if (profile && profile.user_id) {
+        const nickname = profile.nickname || "未命名账号";
+        const text = "当前网易云账号：" + nickname + "（ID：" + profile.user_id + "）";
+        targets.forEach(function (element) {
+          element.textContent = text;
+          element.style.color = "var(--success)";
+        });
+        return;
+      }
+      const text = "当前网易云账号：" + (message || "未登录");
+      targets.forEach(function (element) {
+        element.textContent = text;
+        element.style.color = isError ? "var(--danger)" : "var(--ink-faint)";
+      });
+    }
+
+    async function loadNeteaseAccountStatus(configured) {
+      if (!configured) {
+        renderNeteaseAccount(null, "未登录", false);
+        return;
+      }
+      renderNeteaseAccount(null, "检测中...", false);
+      try {
+        const data = await AdminShell.req("/admin/api/netease/account");
+        if (data.logged_in) {
+          renderNeteaseAccount(data.profile || null, "", false);
+        } else {
+          renderNeteaseAccount(null, data.message || "未登录或 Cookie 已过期", false);
+        }
+      } catch (error) {
+        renderNeteaseAccount(null, error.message || "账号状态检测失败", true);
+      }
+    }
+
+    function setNeteaseQrSaveEnabled(enabled) {
+      const persistButton = AdminShell.byId("cfg_netease_qr_save_persist");
+      const runtimeButton = AdminShell.byId("cfg_netease_qr_save_runtime");
+      if (persistButton) {
+        persistButton.disabled = !enabled;
+      }
+      if (runtimeButton) {
+        runtimeButton.disabled = !enabled;
+      }
+    }
+
+    function stopNeteaseQrPolling() {
+      if (neteaseQrTimer) {
+        window.clearInterval(neteaseQrTimer);
+        neteaseQrTimer = null;
+      }
+    }
+
+    function resetNeteaseQrView(text) {
+      const image = AdminShell.byId("cfg_netease_qr_img");
+      const empty = AdminShell.byId("cfg_netease_qr_empty");
+      const link = AdminShell.byId("cfg_netease_qr_link");
+      if (image) {
+        image.hidden = true;
+        image.removeAttribute("src");
+      }
+      if (empty) {
+        empty.hidden = false;
+        empty.textContent = text || "等待刷新";
+      }
+      if (link) {
+        link.hidden = true;
+        link.href = "#";
+      }
+    }
+
+    function fillNeteaseCookie(cookie) {
+      setSecretValue("cfg_netease_cookie", cookie, true);
+      setNeteaseQrSaveEnabled(!!cookie);
+    }
+
+    async function checkNeteaseQr() {
+      if (!neteaseQrKey) {
+        stopNeteaseQrPolling();
+        return;
+      }
+      try {
+        const data = await AdminShell.req("/admin/api/netease/login/qr/check", {
+          method: "POST",
+          body: JSON.stringify({
+            base_url: neteaseQrBaseUrl || val("cfg_netease_base_url"),
+            key: neteaseQrKey,
+          }),
+        });
+        if (data.status === "waiting") {
+          setNeteaseQrStatus(data.message || "等待扫码", false);
+          return;
+        }
+        if (data.status === "scanned") {
+          setNeteaseQrStatus(data.message || "已扫码，请在手机上确认", false);
+          return;
+        }
+        if (data.status === "expired") {
+          stopNeteaseQrPolling();
+          neteaseQrKey = "";
+          setNeteaseQrStatus(data.message || "二维码已过期", true);
+          resetNeteaseQrView("已过期");
+          setPageState("网易云二维码过期", "warning");
+          return;
+        }
+        if (data.status === "success") {
+          stopNeteaseQrPolling();
+          neteaseQrKey = "";
+          fillNeteaseCookie(data.cookie || "");
+          renderNeteaseAccount(data.profile || null, data.profile_message || "已登录，账号信息待保存后刷新", false);
+          setNeteaseQrStatus("登录成功，Cookie 已填入", false);
+          AdminShell.showMessage("msg", "网易云 Cookie 已填入，可选择保存方式");
+          setPageState("网易云登录成功", "success");
+          return;
+        }
+        setNeteaseQrStatus(data.message || "等待网易云返回登录状态", false);
+      } catch (error) {
+        stopNeteaseQrPolling();
+        neteaseQrKey = "";
+        setNeteaseQrStatus(error.message || "登录状态检查失败", true);
+        setPageState("网易云登录检查失败", "error");
+      }
+    }
+
+    async function refreshNeteaseQr() {
+      const button = AdminShell.byId("cfg_netease_qr_refresh");
+      stopNeteaseQrPolling();
+      neteaseQrKey = "";
+      neteaseQrBaseUrl = "";
+      setNeteaseQrSaveEnabled(false);
+      resetNeteaseQrView("刷新中");
+      setNeteaseQrStatus("正在获取二维码...", false);
+      setPageState("网易云二维码刷新中", "warning");
+      if (button) {
+        button.disabled = true;
+        button.textContent = "刷新中...";
+      }
+      try {
+        const data = await AdminShell.req("/admin/api/netease/login/qr", {
+          method: "POST",
+          body: JSON.stringify({ base_url: val("cfg_netease_base_url") }),
+        });
+        neteaseQrKey = data.key || "";
+        neteaseQrBaseUrl = data.base_url || val("cfg_netease_base_url");
+        const image = AdminShell.byId("cfg_netease_qr_img");
+        const empty = AdminShell.byId("cfg_netease_qr_empty");
+        const link = AdminShell.byId("cfg_netease_qr_link");
+        if (image && data.qrimg) {
+          image.src = data.qrimg;
+          image.hidden = false;
+        }
+        if (empty) {
+          empty.hidden = !!data.qrimg;
+          empty.textContent = data.qrimg ? "" : "二维码链接已生成";
+        }
+        if (link && data.qrurl) {
+          link.href = data.qrurl;
+          link.hidden = false;
+        }
+        setNeteaseQrStatus(data.message || "等待扫码", false);
+        neteaseQrTimer = window.setInterval(checkNeteaseQr, 2500);
+        window.setTimeout(checkNeteaseQr, 900);
+      } catch (error) {
+        resetNeteaseQrView("刷新失败");
+        setNeteaseQrStatus(error.message || "二维码刷新失败", true);
+        setPageState("网易云二维码刷新失败", "error");
+      } finally {
+        if (button) {
+          button.disabled = false;
+          button.textContent = "刷新二维码";
+        }
+      }
+    }
+
+    async function saveNeteaseQrCookie(persist) {
+      if (!val("cfg_netease_cookie")) {
+        setNeteaseQrStatus("请先完成扫码登录", true);
+        return;
+      }
+      await saveConfig(!!persist);
+    }
+
+    let bilibiliQrTimer = null;
+    let bilibiliQrKey = "";
+
+    function setBilibiliQrStatus(text, isError) {
+      const element = AdminShell.byId("cfg_bilibili_qr_status");
+      if (!element) {
+        return;
+      }
+      element.textContent = text || "";
+      element.style.color = isError ? "var(--danger)" : "var(--ink-faint)";
+    }
+
+    function renderBilibiliAccount(profile, message, isError) {
+      const targets = Array.from(document.querySelectorAll("[data-bilibili-account-status]"));
+      const legacy = AdminShell.byId("cfg_bilibili_account_status");
+      if (legacy && !targets.includes(legacy)) {
+        targets.push(legacy);
+      }
+      let text = "";
+      if (!targets.length) {
+        if (profile && profile.user_id) {
+          const nickname = profile.nickname || "未命名账号";
+          setBilibiliQrStatus("当前B站账号：" + nickname + "（ID：" + profile.user_id + "）", false);
+        } else if (message) {
+          setBilibiliQrStatus("当前B站账号：" + message, !!isError);
+        }
+        return;
+      }
+      if (profile && profile.user_id) {
+        const nickname = profile.nickname || "未命名账号";
+        text = "当前B站账号：" + nickname + "（ID：" + profile.user_id + "）";
+        targets.forEach(function (element) {
+          element.textContent = text;
+          element.style.color = "var(--success)";
+        });
+        return;
+      }
+      text = "当前B站账号：" + (message || "未登录");
+      targets.forEach(function (element) {
+        element.textContent = text;
+        element.style.color = isError ? "var(--danger)" : "var(--ink-faint)";
+      });
+    }
+
+    function bilibiliAccountText(profile, fallback) {
+      if (profile && profile.user_id) {
+        const nickname = profile.nickname || "未命名账号";
+        return "当前B站账号：" + nickname + "（ID：" + profile.user_id + "）";
+      }
+      return fallback || "当前B站账号：已登录，账号信息待保存后刷新";
+    }
+
+    async function loadBilibiliAccountStatus(configured) {
+      if (!configured) {
+        renderBilibiliAccount(null, "未登录", false);
+        return;
+      }
+      renderBilibiliAccount(null, "检测中...", false);
+      try {
+        const data = await AdminShell.req("/admin/api/bilibili/account");
+        if (data.logged_in) {
+          renderBilibiliAccount(data.profile || null, "", false);
+        } else {
+          renderBilibiliAccount(null, data.message || "未登录或 Cookie 已过期", false);
+        }
+      } catch (error) {
+        renderBilibiliAccount(null, error.message || "账号状态检测失败", true);
+      }
+    }
+
+    function setBilibiliQrSaveEnabled(enabled) {
+      const persistButton = AdminShell.byId("cfg_bilibili_qr_save_persist");
+      const runtimeButton = AdminShell.byId("cfg_bilibili_qr_save_runtime");
+      if (persistButton) {
+        persistButton.disabled = !enabled;
+      }
+      if (runtimeButton) {
+        runtimeButton.disabled = !enabled;
+      }
+    }
+
+    function stopBilibiliQrPolling() {
+      if (bilibiliQrTimer) {
+        window.clearInterval(bilibiliQrTimer);
+        bilibiliQrTimer = null;
+      }
+    }
+
+    function resetBilibiliQrView(text) {
+      const image = AdminShell.byId("cfg_bilibili_qr_img");
+      const empty = AdminShell.byId("cfg_bilibili_qr_empty");
+      const link = AdminShell.byId("cfg_bilibili_qr_link");
+      if (image) {
+        image.hidden = true;
+        image.removeAttribute("src");
+      }
+      if (empty) {
+        empty.hidden = false;
+        empty.textContent = text || "等待刷新";
+      }
+      if (link) {
+        link.hidden = true;
+        link.href = "#";
+      }
+    }
+
+    function fillBilibiliCookie(cookie) {
+      setSecretValue("cfg_bilibili_cookie", cookie, true);
+      setBilibiliQrSaveEnabled(!!cookie);
+    }
+
+    async function checkBilibiliQr() {
+      if (!bilibiliQrKey) {
+        stopBilibiliQrPolling();
+        return;
+      }
+      try {
+        const data = await AdminShell.req("/admin/api/bilibili/login/qr/check", {
+          method: "POST",
+          body: JSON.stringify({ key: bilibiliQrKey }),
+        });
+        if (data.status === "waiting") {
+          setBilibiliQrStatus(data.message || "等待扫码", false);
+          return;
+        }
+        if (data.status === "scanned") {
+          setBilibiliQrStatus(data.message || "已扫码，请在手机上确认", false);
+          return;
+        }
+        if (data.status === "expired") {
+          stopBilibiliQrPolling();
+          bilibiliQrKey = "";
+          setBilibiliQrStatus(data.message || "二维码已过期", true);
+          resetBilibiliQrView("已过期");
+          setPageState("B 站二维码过期", "warning");
+          return;
+        }
+        if (data.status === "success") {
+          stopBilibiliQrPolling();
+          bilibiliQrKey = "";
+          fillBilibiliCookie(data.cookie || "");
+          const accountText = bilibiliAccountText(data.profile || null, data.profile_message || "");
+          renderBilibiliAccount(data.profile || null, data.profile_message || "已登录，账号信息待保存后刷新", false);
+          setBilibiliQrStatus("登录成功，Cookie 已填入", false);
+          AdminShell.showMessage("msg", "B 站 Cookie 已填入，可选择保存方式；" + accountText);
+          setPageState("B 站登录成功", "success");
+          return;
+        }
+        setBilibiliQrStatus(data.message || "等待 B 站返回登录状态", false);
+      } catch (error) {
+        stopBilibiliQrPolling();
+        bilibiliQrKey = "";
+        setBilibiliQrStatus(error.message || "登录状态检查失败", true);
+        setPageState("B 站登录检查失败", "error");
+      }
+    }
+
+    async function refreshBilibiliQr() {
+      const button = AdminShell.byId("cfg_bilibili_qr_refresh");
+      stopBilibiliQrPolling();
+      bilibiliQrKey = "";
+      setBilibiliQrSaveEnabled(false);
+      resetBilibiliQrView("刷新中");
+      setBilibiliQrStatus("正在获取二维码...", false);
+      setPageState("B 站二维码刷新中", "warning");
+      if (button) {
+        button.disabled = true;
+        button.textContent = "刷新中...";
+      }
+      try {
+        const data = await AdminShell.req("/admin/api/bilibili/login/qr", {
+          method: "POST",
+          body: "{}",
+        });
+        bilibiliQrKey = data.key || "";
+        const image = AdminShell.byId("cfg_bilibili_qr_img");
+        const empty = AdminShell.byId("cfg_bilibili_qr_empty");
+        const link = AdminShell.byId("cfg_bilibili_qr_link");
+        if (image && data.qrimg) {
+          image.src = data.qrimg;
+          image.hidden = false;
+        }
+        if (empty) {
+          empty.hidden = !!data.qrimg;
+          empty.textContent = data.qrimg ? "" : "二维码链接已生成";
+        }
+        if (link && data.qrurl) {
+          link.href = data.qrurl;
+          link.hidden = false;
+        }
+        setBilibiliQrStatus(data.message || "等待扫码", false);
+        bilibiliQrTimer = window.setInterval(checkBilibiliQr, 2500);
+        window.setTimeout(checkBilibiliQr, 900);
+      } catch (error) {
+        resetBilibiliQrView("刷新失败");
+        setBilibiliQrStatus(error.message || "二维码刷新失败", true);
+        setPageState("B 站二维码刷新失败", "error");
+      } finally {
+        if (button) {
+          button.disabled = false;
+          button.textContent = "刷新二维码";
+        }
+      }
+    }
+
+    async function saveBilibiliQrCookie(persist) {
+      if (!val("cfg_bilibili_cookie")) {
+        setBilibiliQrStatus("请先完成扫码登录", true);
+        return;
+      }
+      await saveConfig(!!persist);
+    }
+
     function setSecretState(id, configured) {
       const element = AdminShell.byId(id);
       if (!element) {
@@ -325,7 +739,11 @@
       setSecretValue("cfg_doubao_img_api_key", config.doubao_image?.api_key || "", config.doubao_image?.api_key_configured);
       setSecretValue("cfg_qq_music_cookie", config.qq_music?.cookie || "", config.qq_music?.cookie_configured);
       setSecretValue("cfg_bilibili_cookie", config.bilibili_music?.cookie || "", config.bilibili_music?.cookie_configured);
+      setNeteaseQrSaveEnabled(false);
+      setBilibiliQrSaveEnabled(false);
       renderMusicAreaHint(runtime.music_area || {});
+      await loadNeteaseAccountStatus(!!config.netease?.cookie_configured);
+      await loadBilibiliAccountStatus(!!config.bilibili_music?.cookie_configured);
 
       setPageState("配置已同步", "success");
     }

--- a/src/app/infrastructure/runtime.py
+++ b/src/app/infrastructure/runtime.py
@@ -35,6 +35,15 @@ class MusicGateway:
     def __getattr__(self, name: str):
         return getattr(self.handler, name)
 
+    def refresh_platforms(self) -> dict:
+        """配置热更新时刷新已创建的音乐平台实例。"""
+        if self._handler is None:
+            return {"available": True, "refreshed": False, "reason": "音乐处理器尚未初始化"}
+        refresh = getattr(self._handler, "refresh_platforms", None)
+        if callable(refresh):
+            return refresh()
+        return {"available": False, "refreshed": False, "reason": "音乐处理器不支持刷新"}
+
 
 class PluginRuntime:
     """插件注册、查询和动态装卸的运行时门面。"""

--- a/src/app/lifecycle/background_services.py
+++ b/src/app/lifecycle/background_services.py
@@ -27,11 +27,12 @@ class BackgroundServiceRunner:
         logger.info("自动播放监控已启动。")
 
     def _start_web_player(self, context: AppContext) -> None:
-        from web_player import set_sender, set_plugin_runtime
+        from web_player import register_runtime_dependencies, set_sender
         set_sender(context.sender)
-        set_plugin_runtime(
-            context.handler.infrastructure.plugins,
-            context.handler.plugin_host,
+        register_runtime_dependencies(
+            music=context.handler.infrastructure.music,
+            plugins=context.handler.infrastructure.plugins,
+            plugin_host=context.handler.plugin_host,
         )
         self._warmup_members_cache(context.sender)
         web_host = WEB_PLAYER_CONFIG.get("host", "0.0.0.0")

--- a/src/bilibili_music.py
+++ b/src/bilibili_music.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import re
 import requests
+from http.cookies import SimpleCookie
 from typing import Optional
+from urllib.parse import quote
 
 from logger_config import get_logger
 
@@ -17,14 +19,20 @@ logger = get_logger("BilibiliMusic")
 _API_SEARCH = "https://api.bilibili.com/x/web-interface/search/type"
 _API_AUDIO_INFO = "https://www.bilibili.com/audio/music-service-c/web/song/info"
 _API_AUDIO_URL = "https://www.bilibili.com/audio/music-service-c/web/url"
+_API_VIDEO_VIEW = "https://api.bilibili.com/x/web-interface/view"
 _API_VIDEO_PLAYURL = "https://api.bilibili.com/x/player/playurl"
+_BILIBILI_HOME = "https://www.bilibili.com/"
 
 _HEADERS = {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+    "Cache-Control": "no-cache",
+    "Pragma": "no-cache",
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
     ),
-    "Referer": "https://www.bilibili.com/",
+    "Referer": _BILIBILI_HOME,
 }
 
 
@@ -44,6 +52,38 @@ def _load_config() -> dict:
         return _cached_config
 
 
+def _cookie_dict(raw: str) -> dict[str, str]:
+    """把后台配置里的 Cookie 字符串解析为 Session Cookie。"""
+    text = (raw or "").strip()
+    if not text:
+        return {}
+    try:
+        parsed = SimpleCookie()
+        parsed.load(text)
+        return {name: morsel.value for name, morsel in parsed.items() if morsel.value}
+    except Exception:
+        pairs: dict[str, str] = {}
+        for item in text.split(";"):
+            if "=" not in item:
+                continue
+            name, value = item.split("=", 1)
+            name = name.strip()
+            value = value.strip()
+            if name and value:
+                pairs[name] = value
+        return pairs
+
+
+def _cookie_debug_summary(raw: str) -> str:
+    """生成不含 Cookie 值的调试摘要。"""
+    names = sorted(_cookie_dict(raw).keys())
+    return "configured=%s names=%s" % (bool(names), ",".join(names) or "-")
+
+
+def _bilibili_referer_for_video(bvid: str) -> str:
+    return f"https://www.bilibili.com/video/{bvid}"
+
+
 class BilibiliMusic:
     """B 站音乐平台，实现 MusicPlatform 协议。"""
 
@@ -54,18 +94,56 @@ class BilibiliMusic:
         cfg = _load_config()
         self.enabled = cfg.get("enabled", False)
         self.cookie = cfg.get("cookie", "")
+        self.last_song_url_error = ""
         self._session = requests.Session()
         self._session.headers.update(_HEADERS)
+        cookie_pairs = _cookie_dict(self.cookie)
+        if cookie_pairs:
+            self._session.cookies.update(cookie_pairs)
+        logger.debug("B 站音乐平台初始化: enabled=%s %s", self.enabled, _cookie_debug_summary(self.cookie))
 
-    def _get(self, url: str, params: dict | None = None) -> Optional[dict]:
+    def _prime_session(self) -> None:
+        """刷新 B 站首页 Cookie，降低公开接口偶发 412 的概率。"""
         try:
-            headers = {"Cookie": self.cookie} if self.cookie else {}
-            resp = self._session.get(url, params=params, headers=headers, timeout=10)
+            resp = self._session.get(_BILIBILI_HOME, timeout=10)
+            logger.debug(
+                "B 站首页 Cookie 预热完成: status=%s cookies=%s",
+                getattr(resp, "status_code", "-"),
+                ",".join(sorted(self._session.cookies.keys())) or "-",
+            )
+        except Exception as e:
+            logger.debug("B 站首页 Cookie 预热失败: %s", e)
+
+    def _get(self, url: str, params: dict | None = None, referer: str | None = None) -> Optional[dict]:
+        request_headers = {}
+        if referer:
+            request_headers["Referer"] = referer
+        try:
+            resp = self._session.get(url, params=params, headers=request_headers, timeout=10)
+            if resp.status_code == 412:
+                logger.debug("B 站 API 返回 412，刷新首页 Cookie 后重试: url=%s params=%s", url, params or {})
+                self._prime_session()
+                resp = self._session.get(url, params=params, headers=request_headers, timeout=10)
             resp.raise_for_status()
-            return resp.json()
+            data = resp.json()
+            if isinstance(data, dict):
+                code = data.get("code")
+                if code not in (None, 0):
+                    logger.debug(
+                        "B 站 API 返回业务错误: url=%s code=%s message=%s",
+                        url,
+                        code,
+                        data.get("message") or data.get("msg"),
+                    )
+                return data
+            logger.error("B 站 API 返回格式异常 (%s): %s", url, type(data).__name__)
+            return None
         except Exception as e:
             logger.error("B 站 API 请求失败 (%s): %s", url, e)
             return None
+
+    def _set_last_error(self, message: str) -> None:
+        self.last_song_url_error = message
 
     def search(self, keyword: str, limit: int = 1) -> Optional[dict]:
         results = self._search_audio(keyword, limit)
@@ -89,7 +167,7 @@ class BilibiliMusic:
             "keyword": keyword,
             "page": page,
             "pagesize": limit,
-        })
+        }, referer=f"https://search.bilibili.com/all?keyword={quote(keyword)}")
         if not data or data.get("code") != 0:
             return []
         items = (data.get("data") or {}).get("result") or []
@@ -101,49 +179,137 @@ class BilibiliMusic:
             "keyword": keyword + " 音乐",
             "page": page,
             "pagesize": limit,
-        })
+        }, referer=f"https://search.bilibili.com/all?keyword={quote(keyword)}")
         if not data or data.get("code") != 0:
             return []
         items = (data.get("data") or {}).get("result") or []
         return [p for item in items if (p := self._parse_video(item))]
 
     def get_song_url(self, song_id) -> Optional[str]:
+        self.last_song_url_error = ""
         sid = str(song_id)
         if sid.startswith("au"):
-            return self._get_audio_url(sid[2:])
+            url = self._get_audio_url(sid[2:])
+            if not url and not self.last_song_url_error:
+                self._set_last_error(f"B站无法获取音频链接: {sid}")
+            return url
         if sid.startswith("BV") or sid.startswith("bv"):
-            return self._get_video_audio_url(sid)
+            url = self._get_video_audio_url(sid)
+            if not url and not self.last_song_url_error:
+                self._set_last_error(f"B站无法获取视频音频流: {sid}")
+            return url
         return self._get_audio_url(sid) or self._get_video_audio_url(sid)
 
     def _get_audio_url(self, au_id: str) -> Optional[str]:
-        data = self._get(_API_AUDIO_URL, params={"sid": au_id, "privilege": 2, "quality": 2})
-        if not data or data.get("code") != 0:
+        data = self._get(
+            _API_AUDIO_URL,
+            params={"sid": au_id, "privilege": 2, "quality": 2},
+            referer=f"https://www.bilibili.com/audio/au{au_id}",
+        )
+        if not data:
+            self._set_last_error(f"B站音频链接请求失败: au{au_id}")
+            return None
+        if data.get("code") != 0:
+            self._set_last_error(
+                f"B站音频链接接口返回错误: code={data.get('code')} message={data.get('message') or data.get('msg') or ''}"
+            )
             return None
         cdns = (data.get("data") or {}).get("cdns") or []
+        if not cdns:
+            self._set_last_error(f"B站音频链接为空: au{au_id}")
+            return None
         return cdns[0] if cdns else None
 
+    def _get_video_cid(self, bvid: str) -> Optional[str]:
+        data = self._get(
+            _API_VIDEO_VIEW,
+            params={"bvid": bvid},
+            referer=_bilibili_referer_for_video(bvid),
+        )
+        if not data or data.get("code") != 0:
+            logger.debug("B 站视频 cid 获取失败: bvid=%s", bvid)
+            self._set_last_error(f"B站视频 cid 获取失败: {bvid}")
+            return None
+        video = data.get("data") or {}
+        cid = video.get("cid")
+        pages = video.get("pages") or []
+        if not cid and pages:
+            first = pages[0] if isinstance(pages[0], dict) else {}
+            cid = first.get("cid")
+        if not cid:
+            logger.debug("B 站视频详情缺少 cid: bvid=%s", bvid)
+            self._set_last_error(f"B站视频详情缺少 cid: {bvid}")
+            return None
+        return str(cid)
+
     def _get_video_audio_url(self, bvid: str) -> Optional[str]:
+        cid = self._get_video_cid(bvid)
+        if not cid:
+            return None
         data = self._get(_API_VIDEO_PLAYURL, params={
             "bvid": bvid,
+            "cid": cid,
             "fnval": 16,
             "qn": 64,
-        })
-        if not data or data.get("code") != 0:
+            "fourk": 1,
+        }, referer=_bilibili_referer_for_video(bvid))
+        if not data:
+            self._set_last_error(f"B站视频播放链接请求失败: {bvid}")
+            return None
+        if data.get("code") != 0:
+            logger.debug("B 站视频播放链接接口失败: bvid=%s cid=%s", bvid, cid)
+            self._set_last_error(
+                f"B站视频播放链接接口返回错误: code={data.get('code')} message={data.get('message') or data.get('msg') or ''}"
+            )
             return None
         dash = (data.get("data") or {}).get("dash") or {}
         audio_list = dash.get("audio") or []
         if audio_list:
+            audio_list = sorted(audio_list, key=lambda item: int(item.get("bandwidth") or 0), reverse=True)
+            logger.debug("B 站视频音频链接获取成功: bvid=%s cid=%s audio_count=%s", bvid, cid, len(audio_list))
             return audio_list[0].get("baseUrl") or audio_list[0].get("base_url")
+        durl = (data.get("data") or {}).get("durl") or []
+        if durl:
+            logger.debug("B 站视频播放链接回退到 durl: bvid=%s cid=%s", bvid, cid)
+            return durl[0].get("url")
+        logger.debug("B 站视频播放链接响应中没有 dash.audio/durl: bvid=%s cid=%s", bvid, cid)
+        self._set_last_error(f"B站视频播放链接没有音频流: {bvid}")
         return None
 
     def get_song_detail(self, song_id) -> Optional[dict]:
         sid = str(song_id)
+        if sid.startswith("BV") or sid.startswith("bv"):
+            return self._get_video_detail(sid)
         if sid.startswith("au"):
             sid = sid[2:]
         data = self._get(_API_AUDIO_INFO, params={"sid": sid})
         if data and data.get("code") == 0 and data.get("data"):
             return self._parse_audio_detail(data["data"])
         return None
+
+    def _get_video_detail(self, bvid: str) -> Optional[dict]:
+        data = self._get(
+            _API_VIDEO_VIEW,
+            params={"bvid": bvid},
+            referer=_bilibili_referer_for_video(bvid),
+        )
+        if not data or data.get("code") != 0 or not data.get("data"):
+            return None
+        video = data["data"]
+        owner = video.get("owner") if isinstance(video.get("owner"), dict) else {}
+        duration_s = int(video.get("duration") or 0)
+        cover = video.get("pic") or ""
+        if cover.startswith("//"):
+            cover = "https:" + cover
+        return {
+            "id": video.get("bvid") or bvid,
+            "name": video.get("title") or "未知",
+            "artists": owner.get("name") or video.get("author") or "未知",
+            "album": "",
+            "duration": duration_s * 1000,
+            "durationText": f"{duration_s // 60}:{duration_s % 60:02d}",
+            "cover": cover,
+        }
 
     def get_lyric(self, song_id) -> Optional[str]:
         sid = str(song_id)
@@ -152,6 +318,7 @@ class BilibiliMusic:
         data = self._get(
             "https://www.bilibili.com/audio/music-service-c/web/song/lyric",
             params={"sid": sid},
+            referer=f"https://www.bilibili.com/audio/au{sid}",
         )
         if not data or data.get("code") != 0:
             return None

--- a/src/music.py
+++ b/src/music.py
@@ -21,7 +21,7 @@ from music_web_control import WebControlExecutor
 from music_platform import PlatformRegistry
 from music_playback import (
     PlaybackMixin,
-    reset_web_player_url_cache,  # noqa: F401 — re-export
+    reset_web_player_url_cache,
     _web_player_link,
 )
 
@@ -135,6 +135,18 @@ class MusicHandler(PlaybackMixin):
                 logger.info("B 站音乐平台已注册")
         except Exception as e:
             logger.debug("B 站音乐平台初始化跳过: %s", e)
+
+    def refresh_platforms(self) -> dict:
+        """后台配置变更后刷新平台实例，让新 Cookie 立即用于当前进程。"""
+        self.netease = NeteaseCloud()
+        self.platforms = PlatformRegistry()
+        self.platforms.register(self.netease)
+        self._init_extra_platforms()
+        return {
+            "available": True,
+            "refreshed": True,
+            "platforms": list(self.platforms.available.keys()),
+        }
 
     def _get_web_link(self, area: str = "") -> str:
         """获取 Web 播放器链接（按需生成随机访问令牌）。"""
@@ -373,9 +385,17 @@ class MusicHandler(PlaybackMixin):
         if song.get("url"):
             data = dict(song)
         elif song.get("name") and song.get("artists"):
-            url = p.get_song_url(song_id)
+            try:
+                url = p.get_song_url(
+                    song_id,
+                    expected_duration_ms=song.get("duration", 0) or song.get("duration_ms", 0) or 0,
+                    song_name=song.get("name", ""),
+                )
+            except TypeError:
+                url = p.get_song_url(song_id)
             if not url:
-                self.sender.send_message("错误: 无法获取播放链接", channel=channel, area=area)
+                detail = getattr(p, "last_song_url_error", "") or "无法获取播放链接"
+                self.sender.send_message(f"错误: {detail}", channel=channel, area=area)
                 return
             data = dict(song)
             data["url"] = url

--- a/src/music.py
+++ b/src/music.py
@@ -21,7 +21,7 @@ from music_web_control import WebControlExecutor
 from music_platform import PlatformRegistry
 from music_playback import (
     PlaybackMixin,
-    reset_web_player_url_cache,
+    reset_web_player_url_cache,  # noqa: F401 — re-export
     _web_player_link,
 )
 

--- a/src/netease.py
+++ b/src/netease.py
@@ -3,11 +3,100 @@ import threading
 import requests
 from collections import OrderedDict
 from typing import Optional
+from urllib.parse import urlparse
 
 from config import NETEASE_CLOUD
 from logger_config import get_logger
 
 logger = get_logger("Netease")
+
+
+def _safe_params(params: Optional[dict]) -> dict:
+    safe = dict(params or {})
+    for key in ("cookie", "Cookie"):
+        if key in safe:
+            safe[key] = "<redacted>"
+    return safe
+
+
+def _mask_audio_url(url: object) -> str:
+    text = str(url or "").strip()
+    if not text:
+        return ""
+    try:
+        parsed = urlparse(text)
+        tail = parsed.path.rsplit("/", 1)[-1] if parsed.path else ""
+        suffix = "?..." if parsed.query else ""
+        return f"{parsed.scheme}://{parsed.netloc}/.../{tail}{suffix}"
+    except Exception:
+        no_query = text.split("?", 1)[0]
+        return no_query[:120] + ("..." if len(no_query) > 120 else "")
+
+
+def _compact_trial_value(value):
+    if not isinstance(value, dict):
+        return value
+    keys = (
+        "start",
+        "end",
+        "type",
+        "resConsumable",
+        "userConsumable",
+        "listenType",
+        "cannotListenReason",
+        "playReason",
+        "freeLimitTagType",
+    )
+    return {key: value.get(key) for key in keys if key in value}
+
+
+def _song_url_debug_summary(item: object) -> dict:
+    if not isinstance(item, dict):
+        return {"type": type(item).__name__}
+    return {
+        "id": item.get("id"),
+        "code": item.get("code"),
+        "level": item.get("level"),
+        "encodeType": item.get("encodeType"),
+        "type": item.get("type"),
+        "br": item.get("br"),
+        "size": item.get("size"),
+        "time": item.get("time"),
+        "fee": item.get("fee"),
+        "payed": item.get("payed"),
+        "flag": item.get("flag"),
+        "urlSource": item.get("urlSource"),
+        "rightSource": item.get("rightSource"),
+        "freeTrialInfo": _compact_trial_value(item.get("freeTrialInfo")),
+        "freeTrialPrivilege": _compact_trial_value(item.get("freeTrialPrivilege")),
+        "freeTimeTrialPrivilege": _compact_trial_value(item.get("freeTimeTrialPrivilege")),
+        "url": _mask_audio_url(item.get("url")),
+    }
+
+
+def _looks_like_trial_audio(item: object, expected_duration_ms: int = 0) -> bool:
+    if not isinstance(item, dict):
+        return False
+    if item.get("freeTrialInfo"):
+        return True
+    try:
+        duration_ms = int(item.get("time") or 0)
+    except (TypeError, ValueError):
+        duration_ms = 0
+    try:
+        size = int(item.get("size") or 0)
+    except (TypeError, ValueError):
+        size = 0
+    try:
+        expected_ms = int(expected_duration_ms or 0)
+    except (TypeError, ValueError):
+        expected_ms = 0
+    return expected_ms > 90_000 and 0 < duration_ms <= 65_000 and 0 < size < 2_000_000
+
+
+def _trial_audio_message(song_name: str = "") -> str:
+    label = f"《{song_name}》" if song_name else "该歌曲"
+    return f"{label}只返回了 30 秒左右的试听音频，可能需要会员、单曲购买或受版权限制"
 
 
 class _SearchCache:
@@ -51,28 +140,66 @@ class NeteaseCloud:
         self.cookie = NETEASE_CLOUD.get("cookie", "")
         self._search_cache = _SearchCache()
         self._session = requests.Session()
+        self._last_song_url_error = ""
         if not self.base_url:
             logger.warning("网易云 API 地址未配置 (NETEASE_CLOUD.base_url)")
 
-    def _get(self, path: str, params: Optional[dict] = None) -> Optional[dict]:
-        """发起 GET 请求（复用连接池）"""
+    @property
+    def last_song_url_error(self) -> str:
+        return self._last_song_url_error
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        params: Optional[dict] = None,
+        include_cookie_param: bool = False,
+    ) -> Optional[dict]:
+        """发起网易云 API 请求；需要登录态的接口用 POST body 携带 cookie。"""
         if not self.base_url:
             return None
         try:
+            request_params = dict(params or {})
             headers = {}
             if self.cookie:
                 headers["Cookie"] = self.cookie
-            resp = self._session.get(
-                f"{self.base_url}{path}",
-                params=params,
-                headers=headers,
-                timeout=10,
+            if include_cookie_param and self.cookie:
+                request_params["cookie"] = self.cookie
+            logger.debug(
+                "网易云 API 请求: method=%s path=%s params=%s cookie_configured=%s cookie_in_body=%s",
+                method.upper(),
+                path,
+                _safe_params(request_params),
+                bool(str(self.cookie or "").strip()),
+                include_cookie_param and bool(str(self.cookie or "").strip()),
             )
+            if method.upper() == "POST":
+                resp = self._session.post(
+                    f"{self.base_url}{path}",
+                    data=request_params,
+                    headers=headers,
+                    timeout=10,
+                )
+            else:
+                resp = self._session.get(
+                    f"{self.base_url}{path}",
+                    params=request_params,
+                    headers=headers,
+                    timeout=10,
+                )
             resp.raise_for_status()
             return resp.json()
         except Exception as e:
             logger.error(f"网易云 API 请求失败: {e}")
             return None
+
+    def _get(self, path: str, params: Optional[dict] = None) -> Optional[dict]:
+        """发起 GET 请求（复用连接池）"""
+        return self._request("GET", path, params=params)
+
+    def _post_with_cookie(self, path: str, params: Optional[dict] = None) -> Optional[dict]:
+        """发起带 cookie body 的 POST 请求，供需要会员/登录态的接口使用。"""
+        return self._request("POST", path, params=params, include_cookie_param=True)
 
     def search(self, keyword: str, limit: int = 1) -> Optional[dict]:
         """
@@ -125,16 +252,88 @@ class NeteaseCloud:
                 results.append(parsed)
         return results
 
-    def get_song_url(self, song_id: int) -> Optional[str]:
+    def get_song_url(self, song_id: int, expected_duration_ms: int = 0, song_name: str = "") -> Optional[str]:
         """获取歌曲播放 URL。level 可选 standard(体积小/弱网友好) 或 exhigh(音质更好)。"""
         level = NETEASE_CLOUD.get("audio_quality", "standard")
-        data = self._get("/song/url/v1", params={"id": song_id, "level": level})
-        if not data or data.get("code") != 200:
-            return None
-
-        urls = data.get("data", [])
-        if urls and urls[0].get("url"):
-            return urls[0]["url"]
+        self._last_song_url_error = ""
+        logger.debug(
+            "网易云获取播放链接开始: song_id=%s level=%s expected_duration_ms=%s cookie_configured=%s",
+            song_id,
+            level,
+            expected_duration_ms or 0,
+            bool(str(self.cookie or "").strip()),
+        )
+        requests_to_try = (
+            ("/song/url/v1", {"id": song_id, "level": level}),
+            ("/song/url", {"id": song_id}),
+        )
+        for path, params in requests_to_try:
+            attempts = [("POST", True), ("GET", False)] if self.cookie else [("GET", False)]
+            for method, include_cookie_param in attempts:
+                data = (
+                    self._post_with_cookie(path, params=params)
+                    if method == "POST"
+                    else self._get(path, params=params)
+                )
+                if not data or data.get("code") != 200:
+                    logger.debug(
+                        "网易云播放链接接口未成功: song_id=%s method=%s path=%s code=%s message=%s",
+                        song_id,
+                        method,
+                        path,
+                        data.get("code") if isinstance(data, dict) else None,
+                        data.get("message") if isinstance(data, dict) else None,
+                    )
+                    continue
+                urls = data.get("data", [])
+                if not urls:
+                    logger.debug(
+                        "网易云播放链接接口 data 为空: song_id=%s method=%s path=%s",
+                        song_id,
+                        method,
+                        path,
+                    )
+                    continue
+                first = urls[0]
+                summary = _song_url_debug_summary(first)
+                logger.debug(
+                    "网易云播放链接响应: song_id=%s method=%s path=%s summary=%s",
+                    song_id,
+                    method,
+                    path,
+                    summary,
+                )
+                if isinstance(first, dict) and first.get("url"):
+                    if _looks_like_trial_audio(first, expected_duration_ms=expected_duration_ms):
+                        self._last_song_url_error = _trial_audio_message(song_name)
+                        logger.warning(
+                            "网易云返回疑似试听音频: song_id=%s method=%s path=%s summary=%s",
+                            song_id,
+                            method,
+                            path,
+                            summary,
+                        )
+                        continue
+                    return first["url"]
+                logger.debug(
+                    "网易云播放链接为空: song_id=%s method=%s path=%s summary=%s",
+                    song_id,
+                    method,
+                    path,
+                    summary,
+                )
+                if include_cookie_param:
+                    logger.debug("网易云 POST cookie body 未拿到可用播放链接，继续尝试 GET 兼容路径")
+        if self._last_song_url_error:
+            logger.warning(
+                "网易云播放链接被拒绝: song_id=%s level=%s reason=%s",
+                song_id,
+                level,
+                self._last_song_url_error,
+            )
+        else:
+            self._last_song_url_error = "无法获取播放链接"
+            logger.warning("网易云未获取到播放链接: song_id=%s level=%s", song_id, level)
         return None
 
     def get_user_id(self) -> Optional[int]:
@@ -189,9 +388,14 @@ class NeteaseCloud:
         if not song_info:
             return {"code": "error", "message": f"无法获取歌曲信息: {song_id}", "data": None}
 
-        url = self.get_song_url(song_id)
+        url = self.get_song_url(
+            song_id,
+            expected_duration_ms=song_info.get("duration", 0) or 0,
+            song_name=song_info.get("name", ""),
+        )
         if not url:
-            return {"code": "error", "message": f"无法获取播放链接: {song_info['name']}", "data": None}
+            detail = self.last_song_url_error or f"无法获取播放链接: {song_info['name']}"
+            return {"code": "error", "message": detail, "data": None}
 
         song_info["url"] = url
         return {"code": "success", "message": "", "data": song_info}
@@ -205,9 +409,14 @@ class NeteaseCloud:
         if not song_info:
             return {"code": "error", "message": f"未找到: {keyword}", "data": None}
 
-        url = self.get_song_url(song_info["id"])
+        url = self.get_song_url(
+            song_info["id"],
+            expected_duration_ms=song_info.get("duration", 0) or 0,
+            song_name=song_info.get("name", ""),
+        )
         if not url:
-            return {"code": "error", "message": f"无法获取播放链接: {song_info['name']}", "data": None}
+            detail = self.last_song_url_error or f"无法获取播放链接: {song_info['name']}"
+            return {"code": "error", "message": detail, "data": None}
 
         song_info["url"] = url
 

--- a/src/oopz_sender.py
+++ b/src/oopz_sender.py
@@ -23,7 +23,7 @@ except ImportError:
 from logger_config import get_logger
 from oopz_api import OopzApiMixin
 from proxy_utils import configure_requests_session
-from oopz_upload import UploadMixin, get_image_info  # noqa: F401 — re-export
+from oopz_upload import UploadMixin, get_image_info
 
 logger = get_logger("OopzSender")
 

--- a/src/oopz_sender.py
+++ b/src/oopz_sender.py
@@ -23,7 +23,7 @@ except ImportError:
 from logger_config import get_logger
 from oopz_api import OopzApiMixin
 from proxy_utils import configure_requests_session
-from oopz_upload import UploadMixin, get_image_info
+from oopz_upload import UploadMixin, get_image_info  # noqa: F401 — re-export
 
 logger = get_logger("OopzSender")
 

--- a/src/web_player.py
+++ b/src/web_player.py
@@ -144,6 +144,7 @@ def reset_netease() -> None:
 
 
 _sender = None
+_music_dependency = None
 _plugin_runtime = None
 _plugin_host = None
 
@@ -173,8 +174,27 @@ def get_plugin_host():
 
 def register_runtime_dependencies(*, music=None, plugins=None, plugin_host=None) -> None:
     """兼容旧测试/调用方的运行时依赖注入入口。"""
+    global _music_dependency
+    if music is not None:
+        _music_dependency = music
     if plugins is not None:
         set_plugin_runtime(plugins, plugin_host)
+
+
+def refresh_music_platforms() -> dict:
+    """在配置热更新后刷新已创建的音乐平台实例。"""
+    reset_netease()
+    _platform_cache.clear()
+    if _music_dependency is None:
+        return {"available": False, "reason": "music 未注册"}
+    refresh = getattr(_music_dependency, "refresh_platforms", None)
+    if callable(refresh):
+        return refresh()
+    handler = getattr(_music_dependency, "_handler", None)
+    refresh = getattr(handler, "refresh_platforms", None)
+    if callable(refresh):
+        return refresh()
+    return {"available": False, "reason": "音乐处理器尚未初始化"}
 
 
 def _admin_enabled() -> bool:
@@ -324,16 +344,20 @@ def add_song_to_queue(body: dict, area: str = "") -> dict:
         return {"ok": False, "error": "缺少歌曲 ID"}
     platform = body.get("platform", "netease")
     p = _resolve_platform(platform)
-    url = p.get_song_url(song_id)
-    if not url:
-        return {"ok": False, "error": "无法获取播放链接，可能需要 VIP"}
-
     name = body.get("name", "")
     artists = body.get("artists", "")
     album = body.get("album", "")
     cover = body.get("cover", "")
     duration_ms = body.get("duration", 0)
     duration_text = body.get("durationText", "")
+    try:
+        url = p.get_song_url(song_id, expected_duration_ms=duration_ms or 0, song_name=name)
+    except TypeError:
+        url = p.get_song_url(song_id)
+    if not url:
+        detail = getattr(p, "last_song_url_error", "") or "无法获取播放链接，可能需要 VIP"
+        return {"ok": False, "error": detail}
+
     song_data = {
         "platform": platform,
         "song_id": str(song_id),

--- a/src/web_player_admin.py
+++ b/src/web_player_admin.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import copy
+import io
 import json
 import os
 import secrets
@@ -11,10 +13,24 @@ import string
 import sys
 import time
 from collections import deque
+from http.cookies import SimpleCookie
 from typing import Any, Optional
+from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+
+try:
+    import requests
+    RequestsException = requests.RequestException
+except Exception:
+    requests = None
+    RequestsException = RuntimeError
+
+try:
+    import qrcode
+except Exception:
+    qrcode = None
 
 from database import DB_PATH, MessageStatsDB, ReminderDB, ScheduledMessageDB, SongCache, Statistics, db_connection
 from logger_config import get_logger
@@ -265,6 +281,491 @@ def _get_plugin_runtime():
 def _set_liked_ids_cache(value: list) -> None:
     import web_player
     web_player.liked_ids_cache = value
+
+
+def _normalize_netease_base_url(raw: object = "") -> str:
+    """校验并规范化后台传入的网易云 API 地址。"""
+    value = str(raw or cfg.NETEASE_CLOUD.get("base_url") or "").strip().rstrip("/")
+    if not value:
+        raise ValueError("网易云 API 地址为空")
+    if len(value) > 300:
+        raise ValueError("网易云 API 地址过长")
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("网易云 API 地址必须是 http/https URL")
+    return value
+
+
+def _netease_timestamp_params(extra: dict | None = None) -> dict:
+    """附加时间戳参数，避免网易云登录接口被缓存。"""
+    stamp = str(int(time.time() * 1000))
+    params = {
+        "timestamp": stamp,
+        "timerstamp": stamp,
+    }
+    if extra:
+        params.update(extra)
+    return params
+
+
+def _netease_api_get(
+    base_url: str,
+    path: str,
+    params: dict | None = None,
+    headers: dict | None = None,
+) -> tuple[dict, requests.Response]:
+    """请求本地/远端 NeteaseCloudMusicApi 并返回 JSON。"""
+    if requests is None:
+        raise RuntimeError("缺少 requests 依赖，请先安装 requirements.txt")
+    request_headers = {"Cache-Control": "no-cache"}
+    if headers:
+        request_headers.update(headers)
+    response = requests.get(
+        f"{base_url}{path}",
+        params=params or {},
+        headers=request_headers,
+        timeout=10,
+    )
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ValueError("网易云 API 返回格式异常")
+    return data, response
+
+
+def _netease_api_post(
+    base_url: str,
+    path: str,
+    data: dict | None = None,
+    headers: dict | None = None,
+) -> tuple[dict, requests.Response]:
+    """POST 请求网易云 API；用于避免把长 Cookie 暴露在查询串里。"""
+    if requests is None:
+        raise RuntimeError("缺少 requests 依赖，请先安装 requirements.txt")
+    request_headers = {"Cache-Control": "no-cache"}
+    if headers:
+        request_headers.update(headers)
+    response = requests.post(
+        f"{base_url}{path}",
+        data=data or {},
+        headers=request_headers,
+        timeout=10,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError("网易云 API 返回格式异常")
+    return payload, response
+
+
+def _netease_response_data(payload: dict) -> dict:
+    """兼容不同网易云 API 分支的 data 包装结构。"""
+    data = payload.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _netease_qr_code(payload: dict) -> int:
+    """从扫码检查响应中提取状态码。"""
+    status_codes = {800, 801, 802, 803}
+    values = (_netease_response_data(payload).get("code"), payload.get("code"))
+    parsed_values = []
+    for value in values:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            continue
+        if parsed in status_codes:
+            return parsed
+        parsed_values.append(parsed)
+    if parsed_values:
+        return parsed_values[0]
+    return 0
+
+
+def _cookie_from_response(payload: dict, response: requests.Response) -> str:
+    """优先取接口 JSON 中的 Cookie，回退到响应 Set-Cookie。"""
+    nested = _netease_response_data(payload)
+    cookie = str(payload.get("cookie") or nested.get("cookie") or "").strip()
+    if cookie:
+        logger.debug("网易云扫码登录 Cookie 提取成功: source=json %s", _cookie_debug_summary(cookie))
+        return cookie
+
+    jar = getattr(response, "cookies", None)
+    if jar:
+        try:
+            pairs = [f"{item.name}={item.value}" for item in jar]
+            cookie = "; ".join(pair for pair in pairs if pair)
+            if cookie:
+                logger.debug("网易云扫码登录 Cookie 提取成功: source=response %s", _cookie_debug_summary(cookie))
+                return cookie
+        except Exception:
+            logger.debug("解析网易云登录响应 CookieJar 失败", exc_info=True)
+
+    header = response.headers.get("set-cookie", "") if hasattr(response, "headers") else ""
+    cookie = header.strip()
+    if cookie:
+        logger.debug("网易云扫码登录 Cookie 提取成功: source=set-cookie %s", _cookie_debug_summary(cookie))
+    else:
+        logger.debug("网易云扫码登录响应中未找到可用 Cookie")
+    return cookie
+
+
+def _netease_login_message(payload: dict, default: str = "") -> str:
+    """兼容 message/msg/nested message 三种提示字段。"""
+    nested = _netease_response_data(payload)
+    return str(
+        payload.get("message")
+        or payload.get("msg")
+        or nested.get("message")
+        or nested.get("msg")
+        or default
+    )
+
+
+def _extract_netease_profile(payload: dict) -> Optional[dict]:
+    """从账号接口返回中提取昵称和用户 ID。"""
+    nested = _netease_response_data(payload)
+    profile = payload.get("profile") or nested.get("profile") or {}
+    account = payload.get("account") or nested.get("account") or {}
+    if not isinstance(profile, dict):
+        profile = {}
+    if not isinstance(account, dict):
+        account = {}
+
+    user_id = (
+        profile.get("userId")
+        or profile.get("userid")
+        or profile.get("id")
+        or account.get("id")
+        or account.get("userId")
+    )
+    if not user_id:
+        return None
+
+    nickname = (
+        profile.get("nickname")
+        or profile.get("name")
+        or account.get("userName")
+        or account.get("nickname")
+        or ""
+    )
+    return {
+        "user_id": str(user_id),
+        "nickname": str(nickname or ""),
+        "avatar_url": str(profile.get("avatarUrl") or profile.get("avatarUrlHttps") or ""),
+    }
+
+
+def _netease_account_status(base_url: str, cookie: str) -> dict:
+    """使用 Cookie 查询当前网易云登录账号。"""
+    cookie = (cookie or "").strip()
+    if not cookie:
+        logger.debug("网易云账号状态查询跳过: 未配置 Cookie")
+        return {"ok": True, "logged_in": False, "message": "未配置网易云 Cookie"}
+
+    logger.debug("网易云账号状态查询开始: base_url=%s %s", base_url, _cookie_debug_summary(cookie))
+    requests_to_try = (
+        (
+            "POST",
+            "/login/status",
+            _netease_timestamp_params({"cookie": cookie}),
+        ),
+        (
+            "GET",
+            "/user/account",
+            _netease_timestamp_params(),
+        ),
+    )
+    last_message = ""
+    for method, path, params in requests_to_try:
+        try:
+            logger.debug("网易云账号状态请求: method=%s path=%s", method, path)
+            if method == "POST":
+                payload, _ = _netease_api_post(base_url, path, data=params, headers={"Cookie": cookie})
+            else:
+                payload, _ = _netease_api_get(base_url, path, params=params, headers={"Cookie": cookie})
+        except Exception as exc:
+            last_message = str(exc)
+            logger.debug("网易云账号状态请求失败 (%s %s): %s", method, path, exc)
+            continue
+
+        nested = _netease_response_data(payload)
+        logger.debug(
+            "网易云账号状态接口返回: path=%s code=%s data_code=%s message=%s",
+            path,
+            payload.get("code"),
+            nested.get("code") if isinstance(nested, dict) else None,
+            _netease_login_message(payload, ""),
+        )
+        profile = _extract_netease_profile(payload)
+        if profile:
+            logger.debug("网易云账号状态查询成功: path=%s %s", path, _debug_profile_text(profile))
+            return {
+                "ok": True,
+                "logged_in": True,
+                "profile": profile,
+                "message": "网易云账号已登录",
+            }
+        last_message = _netease_login_message(payload, last_message)
+        logger.debug("网易云账号状态未解析到 profile: path=%s message=%s", path, last_message)
+
+    logger.debug("网易云账号状态查询未登录: message=%s", last_message)
+    return {
+        "ok": True,
+        "logged_in": False,
+        "message": last_message or "Cookie 未登录或已过期",
+    }
+
+
+_BILIBILI_LOGIN_BASE = "https://passport.bilibili.com"
+_BILIBILI_API_BASE = "https://api.bilibili.com"
+_BILIBILI_QR_GENERATE_PATH = "/x/passport-login/web/qrcode/generate"
+_BILIBILI_QR_POLL_PATH = "/x/passport-login/web/qrcode/poll"
+_BILIBILI_NAV_PATH = "/x/web-interface/nav"
+_BILIBILI_COOKIE_NAMES = (
+    "SESSDATA",
+    "bili_jct",
+    "DedeUserID",
+    "DedeUserID__ckMd5",
+    "sid",
+)
+
+
+def _make_qr_data_uri(content: str) -> str:
+    """把登录 URL 渲染为前端可直接展示的二维码 PNG。"""
+    if qrcode is None:
+        raise RuntimeError("缺少 qrcode 依赖，请先安装 requirements.txt")
+    image = qrcode.make(content)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def _bilibili_api_get(path: str, params: dict | None = None) -> tuple[dict, requests.Response]:
+    """请求 B 站 Web 扫码登录接口并返回 JSON。"""
+    if requests is None:
+        raise RuntimeError("缺少 requests 依赖，请先安装 requirements.txt")
+    response = requests.get(
+        f"{_BILIBILI_LOGIN_BASE}{path}",
+        params=params or {},
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+            ),
+            "Referer": "https://www.bilibili.com/",
+            "Cache-Control": "no-cache",
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ValueError("B 站 API 返回格式异常")
+    return data, response
+
+
+def _bilibili_account_api_get(path: str, headers: dict | None = None) -> tuple[dict, requests.Response]:
+    """请求 B 站 Web API，用于读取已登录账号信息。"""
+    if requests is None:
+        raise RuntimeError("缺少 requests 依赖，请先安装 requirements.txt")
+    request_headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+        ),
+        "Referer": "https://www.bilibili.com/",
+        "Cache-Control": "no-cache",
+    }
+    if headers:
+        request_headers.update(headers)
+    response = requests.get(
+        f"{_BILIBILI_API_BASE}{path}",
+        headers=request_headers,
+        timeout=10,
+    )
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise ValueError("B 站 API 返回格式异常")
+    return data, response
+
+
+def _bilibili_response_data(payload: dict) -> dict:
+    """兼容 B 站响应中的 data 包装结构。"""
+    data = payload.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _bilibili_login_message(payload: dict, default: str = "") -> str:
+    """提取 B 站扫码接口返回的提示。"""
+    nested = _bilibili_response_data(payload)
+    return str(
+        nested.get("message")
+        or payload.get("message")
+        or payload.get("msg")
+        or default
+    )
+
+
+def _bilibili_qr_code(payload: dict) -> int:
+    """从 B 站扫码轮询响应中提取状态码。"""
+    nested = _bilibili_response_data(payload)
+    for value in (nested.get("code"), payload.get("code")):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            continue
+    return -1
+
+
+def _cookie_pairs_from_response(response: requests.Response, allowed_names: tuple[str, ...] = ()) -> str:
+    """从 CookieJar 或 Set-Cookie 头中整理出可配置的 Cookie 字符串。"""
+    allowed = set(allowed_names)
+    pairs: list[str] = []
+    jar = getattr(response, "cookies", None)
+    if jar:
+        try:
+            for item in jar:
+                name = getattr(item, "name", "")
+                value = getattr(item, "value", "")
+                if name and value and (not allowed or name in allowed):
+                    pairs.append(f"{name}={value}")
+        except Exception:
+            logger.debug("解析登录响应 CookieJar 失败", exc_info=True)
+    if pairs:
+        return "; ".join(pairs)
+
+    header = response.headers.get("set-cookie", "") if hasattr(response, "headers") else ""
+    if header:
+        try:
+            cookie = SimpleCookie()
+            cookie.load(header)
+            for name, morsel in cookie.items():
+                if morsel.value and (not allowed or name in allowed):
+                    pairs.append(f"{name}={morsel.value}")
+        except Exception:
+            logger.debug("解析 Set-Cookie 头失败", exc_info=True)
+    return "; ".join(pairs)
+
+
+def _mask_debug_token(value: str, prefix: int = 6, suffix: int = 4) -> str:
+    """日志中遮罩 token/key，避免泄露可复用凭据。"""
+    text = str(value or "")
+    if not text:
+        return "-"
+    if len(text) <= prefix + suffix:
+        return "*" * len(text)
+    return f"{text[:prefix]}...{text[-suffix:]}"
+
+
+def _cookie_debug_summary(cookie: str) -> str:
+    """生成不含 Cookie 值的调试摘要。"""
+    text = (cookie or "").strip()
+    names: list[str] = []
+    if text:
+        try:
+            parsed = SimpleCookie()
+            parsed.load(text)
+            names = [name for name, morsel in parsed.items() if morsel.value]
+        except Exception:
+            names = []
+        if not names:
+            for item in text.split(";"):
+                name = item.split("=", 1)[0].strip()
+                if name:
+                    names.append(name)
+    names_text = ",".join(names) if names else "-"
+    return f"len={len(text)} names={names_text}"
+
+
+def _debug_profile_text(profile: Optional[dict]) -> str:
+    """生成账号资料调试文本。"""
+    if not profile:
+        return "profile=-"
+    return "nickname=%s uid=%s" % (
+        profile.get("nickname") or "",
+        profile.get("user_id") or "",
+    )
+
+
+def _bilibili_cookie_from_poll(payload: dict, response: requests.Response) -> str:
+    """优先取 Set-Cookie，回退到跨域登录 URL 中的 Cookie 参数。"""
+    cookie = _cookie_pairs_from_response(response, _BILIBILI_COOKIE_NAMES)
+    if cookie:
+        logger.debug("B 站扫码登录 Cookie 提取成功: source=response %s", _cookie_debug_summary(cookie))
+        return cookie
+
+    login_url = str(_bilibili_response_data(payload).get("url") or "").strip()
+    if not login_url:
+        logger.debug("B 站扫码登录未拿到跨域登录 URL，无法回退提取 Cookie")
+        return ""
+    try:
+        query = parse_qs(urlparse(login_url).query)
+    except Exception:
+        logger.debug("B 站扫码登录 URL 解析失败，无法回退提取 Cookie", exc_info=True)
+        return ""
+    pairs = []
+    for name in _BILIBILI_COOKIE_NAMES:
+        values = query.get(name)
+        if values and values[0]:
+            pairs.append(f"{name}={values[0]}")
+    cookie = "; ".join(pairs)
+    if cookie:
+        logger.debug("B 站扫码登录 Cookie 提取成功: source=url %s", _cookie_debug_summary(cookie))
+    else:
+        logger.debug("B 站扫码登录 URL 中未找到可用 Cookie 字段")
+    return cookie
+
+
+def _extract_bilibili_profile(payload: dict) -> Optional[dict]:
+    """从 B 站导航栏接口返回中提取昵称和 UID。"""
+    data = _bilibili_response_data(payload)
+    if not isinstance(data, dict) or not data.get("isLogin"):
+        return None
+    user_id = data.get("mid") or data.get("uid")
+    if not user_id:
+        return None
+    return {
+        "user_id": str(user_id),
+        "nickname": str(data.get("uname") or data.get("name") or ""),
+        "avatar_url": str(data.get("face") or ""),
+    }
+
+
+def _bilibili_account_status(cookie: str) -> dict:
+    """使用 Cookie 查询当前 B 站登录账号。"""
+    cookie = (cookie or "").strip()
+    if not cookie:
+        logger.debug("B 站账号状态查询跳过: 未配置 Cookie")
+        return {"ok": True, "logged_in": False, "message": "未配置 B 站 Cookie"}
+
+    logger.debug("B 站账号状态查询开始: %s", _cookie_debug_summary(cookie))
+    payload, _ = _bilibili_account_api_get(
+        _BILIBILI_NAV_PATH,
+        headers={"Cookie": cookie},
+    )
+    data = _bilibili_response_data(payload)
+    logger.debug(
+        "B 站账号状态接口返回: code=%s isLogin=%s message=%s",
+        payload.get("code"),
+        data.get("isLogin") if isinstance(data, dict) else None,
+        _bilibili_login_message(payload, ""),
+    )
+    profile = _extract_bilibili_profile(payload)
+    if profile:
+        logger.debug("B 站账号状态查询成功: %s", _debug_profile_text(profile))
+        return {
+            "ok": True,
+            "logged_in": True,
+            "profile": profile,
+            "message": "B 站账号已登录",
+        }
+
+    message = _bilibili_login_message(payload, "Cookie 未登录或已过期")
+    logger.debug("B 站账号状态查询未登录: message=%s", message)
+    return {"ok": True, "logged_in": False, "message": message}
 
 
 _ADMIN_SHELL_TEMPLATE: string.Template | None = None
@@ -701,6 +1202,7 @@ async def admin_update_config(request: Request):
     updates = body.get("updates", {})
     persist = bool(body.get("persist", True))
     applied, errors, persist_payload = cfg.apply_config_updates(updates)
+    music_runtime = {}
 
     import web_player
     if "redis" in applied:
@@ -708,6 +1210,12 @@ async def admin_update_config(request: Request):
     if "netease" in applied:
         web_player.reset_netease()
         _set_liked_ids_cache([])
+    if {"netease", "qq_music", "bilibili_music"} & set(applied):
+        try:
+            music_runtime = web_player.refresh_music_platforms()
+        except Exception as exc:
+            logger.exception("刷新音乐平台运行时失败")
+            errors.append(f"音乐平台刷新失败: {exc}")
     if "music" in applied and "default_volume" in applied["music"]:
         try:
             volume = cfg.default_music_volume()
@@ -729,8 +1237,340 @@ async def admin_update_config(request: Request):
         "config": cfg.config_snapshot(),
         "runtime": {
             "music_area": _music_area_context(),
+            "music_platforms": music_runtime,
         },
     })
+
+
+@admin_router.post("/admin/api/netease/login/qr")
+async def admin_netease_login_qr(request: Request):
+    """创建网易云扫码登录二维码。"""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+
+    try:
+        base_url = _normalize_netease_base_url(body.get("base_url"))
+        logger.debug("网易云扫码登录二维码刷新请求开始: base_url=%s", base_url)
+        key_payload, _ = _netease_api_get(
+            base_url,
+            "/login/qr/key",
+            params=_netease_timestamp_params(),
+        )
+        key_data = _netease_response_data(key_payload)
+        unikey = str(key_data.get("unikey") or key_payload.get("unikey") or "").strip()
+        if not unikey:
+            message = _netease_login_message(key_payload, "二维码 key 获取失败")
+            logger.debug(
+                "网易云扫码登录二维码 key 获取失败: code=%s message=%s",
+                key_payload.get("code"),
+                message,
+            )
+            return JSONResponse({"ok": False, "error": message}, status_code=502)
+
+        qr_payload, _ = _netease_api_get(
+            base_url,
+            "/login/qr/create",
+            params=_netease_timestamp_params({
+                "key": unikey,
+                "qrimg": "true",
+            }),
+        )
+        qr_data = _netease_response_data(qr_payload)
+        qrimg = str(qr_data.get("qrimg") or qr_payload.get("qrimg") or "").strip()
+        qrurl = str(qr_data.get("qrurl") or qr_payload.get("qrurl") or "").strip()
+        if qrimg and not qrimg.startswith("data:"):
+            qrimg = f"data:image/png;base64,{qrimg}"
+        if not qrimg and not qrurl:
+            message = _netease_login_message(qr_payload, "二维码生成失败")
+            logger.debug(
+                "网易云扫码登录二维码响应缺少字段: key=%s qrimg_present=%s qrurl_present=%s message=%s",
+                _mask_debug_token(unikey),
+                bool(qrimg),
+                bool(qrurl),
+                message,
+            )
+            return JSONResponse({"ok": False, "error": message}, status_code=502)
+
+        logger.debug(
+            "网易云扫码登录二维码刷新成功: key=%s qrimg_len=%s qrurl_len=%s",
+            _mask_debug_token(unikey),
+            len(qrimg),
+            len(qrurl),
+        )
+        return JSONResponse({
+            "ok": True,
+            "base_url": base_url,
+            "key": unikey,
+            "qrimg": qrimg,
+            "qrurl": qrurl,
+            "message": "二维码已刷新",
+        })
+    except ValueError as exc:
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+    except RequestsException as exc:
+        logger.warning("网易云扫码登录二维码请求失败: %s", exc)
+        return JSONResponse({"ok": False, "error": f"网易云 API 请求失败: {exc}"}, status_code=502)
+    except Exception as exc:
+        logger.exception("创建网易云扫码登录二维码失败")
+        return JSONResponse({"ok": False, "error": f"创建二维码失败: {exc}"}, status_code=500)
+
+
+@admin_router.post("/admin/api/netease/login/qr/check")
+async def admin_netease_login_qr_check(request: Request):
+    """检查网易云扫码登录状态，成功时返回 Cookie。"""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+
+    key = str(body.get("key") or "").strip()
+    if not key:
+        return JSONResponse({"ok": False, "error": "二维码 key 不能为空"}, status_code=400)
+
+    try:
+        base_url = _normalize_netease_base_url(body.get("base_url"))
+        logger.debug("网易云扫码登录轮询开始: key=%s base_url=%s", _mask_debug_token(key), base_url)
+        payload, response = _netease_api_get(
+            base_url,
+            "/login/qr/check",
+            params=_netease_timestamp_params({"key": key}),
+        )
+        code = _netease_qr_code(payload)
+        message = _netease_login_message(payload)
+        status_map = {
+            800: "expired",
+            801: "waiting",
+            802: "scanned",
+            803: "success",
+        }
+        status = status_map.get(code, "unknown")
+        logger.debug(
+            "网易云扫码登录轮询结果: key=%s code=%s status=%s message=%s",
+            _mask_debug_token(key),
+            code,
+            status,
+            message,
+        )
+        result = {
+            "ok": True,
+            "base_url": base_url,
+            "code": code,
+            "status": status,
+            "message": message,
+        }
+        if code == 803:
+            cookie = _cookie_from_response(payload, response)
+            if not cookie:
+                return JSONResponse(
+                    {"ok": False, "error": "扫码成功但网易云 API 未返回 Cookie"},
+                    status_code=502,
+                )
+            result["cookie"] = cookie
+            try:
+                account_status = _netease_account_status(base_url, cookie)
+                if account_status.get("logged_in"):
+                    result["profile"] = account_status.get("profile")
+                    logger.debug(
+                        "网易云扫码登录成功并识别账号: key=%s %s",
+                        _mask_debug_token(key),
+                        _debug_profile_text(account_status.get("profile")),
+                    )
+                else:
+                    result["profile_message"] = account_status.get("message", "")
+                    logger.debug(
+                        "网易云扫码登录成功但账号未识别: key=%s message=%s",
+                        _mask_debug_token(key),
+                        result["profile_message"],
+                    )
+            except Exception as exc:
+                logger.debug("网易云扫码成功后查询账号信息失败: %s", exc)
+                result["profile_message"] = f"账号信息查询失败: {exc}"
+            result["message"] = message or "登录成功"
+        return JSONResponse(result)
+    except ValueError as exc:
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+    except RequestsException as exc:
+        logger.warning("网易云扫码登录状态检查失败: %s", exc)
+        return JSONResponse({"ok": False, "error": f"网易云 API 请求失败: {exc}"}, status_code=502)
+    except Exception as exc:
+        logger.exception("检查网易云扫码登录状态失败")
+        return JSONResponse({"ok": False, "error": f"检查登录状态失败: {exc}"}, status_code=500)
+
+
+@admin_router.get("/admin/api/netease/account")
+def admin_netease_account():
+    """返回当前配置 Cookie 对应的网易云账号信息。"""
+    try:
+        base_url = _normalize_netease_base_url(cfg.NETEASE_CLOUD.get("base_url"))
+        cookie = str(cfg.NETEASE_CLOUD.get("cookie") or "")
+        logger.debug("网易云账号状态接口请求: base_url=%s %s", base_url, _cookie_debug_summary(cookie))
+        status = _netease_account_status(base_url, cookie)
+        if status.get("logged_in"):
+            logger.debug("网易云账号状态接口响应: logged_in=True %s", _debug_profile_text(status.get("profile")))
+        else:
+            logger.debug("网易云账号状态接口响应: logged_in=False message=%s", status.get("message", ""))
+        return JSONResponse(status)
+    except ValueError as exc:
+        return JSONResponse({"ok": True, "logged_in": False, "message": str(exc)})
+    except RequestsException as exc:
+        logger.warning("网易云账号状态查询失败: %s", exc)
+        return JSONResponse({"ok": True, "logged_in": False, "message": f"网易云 API 请求失败: {exc}"})
+    except Exception as exc:
+        logger.warning("网易云账号状态查询异常: %s", exc, exc_info=True)
+        return JSONResponse({"ok": True, "logged_in": False, "message": f"账号状态查询失败: {exc}"})
+
+
+@admin_router.post("/admin/api/bilibili/login/qr")
+async def admin_bilibili_login_qr():
+    """创建 B 站扫码登录二维码。"""
+    try:
+        logger.debug("B 站扫码登录二维码刷新请求开始")
+        payload, _ = _bilibili_api_get(_BILIBILI_QR_GENERATE_PATH)
+        if int(payload.get("code", -1)) != 0:
+            message = _bilibili_login_message(payload, "二维码生成失败")
+            logger.debug("B 站扫码登录二维码刷新失败: code=%s message=%s", payload.get("code"), message)
+            return JSONResponse({"ok": False, "error": message}, status_code=502)
+
+        data = _bilibili_response_data(payload)
+        key = str(data.get("qrcode_key") or "").strip()
+        qrurl = str(data.get("url") or "").strip()
+        if not key or not qrurl:
+            message = _bilibili_login_message(payload, "二维码生成失败")
+            logger.debug(
+                "B 站扫码登录二维码响应缺少字段: key_present=%s qrurl_present=%s message=%s",
+                bool(key),
+                bool(qrurl),
+                message,
+            )
+            return JSONResponse({"ok": False, "error": message}, status_code=502)
+
+        logger.debug(
+            "B 站扫码登录二维码刷新成功: key=%s qrurl_len=%s",
+            _mask_debug_token(key),
+            len(qrurl),
+        )
+        return JSONResponse({
+            "ok": True,
+            "key": key,
+            "qrimg": _make_qr_data_uri(qrurl),
+            "qrurl": qrurl,
+            "message": "二维码已刷新",
+        })
+    except RequestsException as exc:
+        logger.warning("B 站扫码登录二维码请求失败: %s", exc)
+        return JSONResponse({"ok": False, "error": f"B 站 API 请求失败: {exc}"}, status_code=502)
+    except Exception as exc:
+        logger.exception("创建 B 站扫码登录二维码失败")
+        return JSONResponse({"ok": False, "error": f"创建二维码失败: {exc}"}, status_code=500)
+
+
+@admin_router.post("/admin/api/bilibili/login/qr/check")
+async def admin_bilibili_login_qr_check(request: Request):
+    """检查 B 站扫码登录状态，成功时返回 Cookie。"""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+
+    key = str(body.get("key") or "").strip()
+    if not key:
+        return JSONResponse({"ok": False, "error": "二维码 key 不能为空"}, status_code=400)
+
+    try:
+        logger.debug("B 站扫码登录轮询开始: key=%s", _mask_debug_token(key))
+        payload, response = _bilibili_api_get(
+            _BILIBILI_QR_POLL_PATH,
+            params={"qrcode_key": key},
+        )
+        if int(payload.get("code", -1)) != 0:
+            message = _bilibili_login_message(payload, "登录状态检查失败")
+            logger.debug(
+                "B 站扫码登录轮询接口失败: key=%s code=%s message=%s",
+                _mask_debug_token(key),
+                payload.get("code"),
+                message,
+            )
+            return JSONResponse({"ok": False, "error": message}, status_code=502)
+
+        code = _bilibili_qr_code(payload)
+        message = _bilibili_login_message(payload)
+        status_map = {
+            0: "success",
+            86038: "expired",
+            86090: "scanned",
+            86101: "waiting",
+        }
+        status = status_map.get(code, "unknown")
+        logger.debug(
+            "B 站扫码登录轮询结果: key=%s code=%s status=%s message=%s",
+            _mask_debug_token(key),
+            code,
+            status,
+            message,
+        )
+        result = {
+            "ok": True,
+            "code": code,
+            "status": status,
+            "message": message,
+        }
+        if code == 0:
+            cookie = _bilibili_cookie_from_poll(payload, response)
+            if not cookie:
+                return JSONResponse(
+                    {"ok": False, "error": "扫码成功但 B 站未返回 Cookie"},
+                    status_code=502,
+                )
+            result["cookie"] = cookie
+            try:
+                account_status = _bilibili_account_status(cookie)
+                if account_status.get("logged_in"):
+                    result["profile"] = account_status.get("profile")
+                    logger.debug(
+                        "B 站扫码登录成功并识别账号: key=%s %s",
+                        _mask_debug_token(key),
+                        _debug_profile_text(account_status.get("profile")),
+                    )
+                else:
+                    result["profile_message"] = account_status.get("message", "")
+                    logger.debug(
+                        "B 站扫码登录成功但账号未识别: key=%s message=%s",
+                        _mask_debug_token(key),
+                        result["profile_message"],
+                    )
+            except Exception as exc:
+                logger.debug("B 站扫码成功后查询账号信息失败: %s", exc)
+                result["profile_message"] = f"账号信息查询失败: {exc}"
+            result["message"] = message or "登录成功"
+        return JSONResponse(result)
+    except RequestsException as exc:
+        logger.warning("B 站扫码登录状态检查失败: %s", exc)
+        return JSONResponse({"ok": False, "error": f"B 站 API 请求失败: {exc}"}, status_code=502)
+    except Exception as exc:
+        logger.exception("检查 B 站扫码登录状态失败")
+        return JSONResponse({"ok": False, "error": f"检查登录状态失败: {exc}"}, status_code=500)
+
+
+@admin_router.get("/admin/api/bilibili/account")
+def admin_bilibili_account():
+    """返回当前配置 Cookie 对应的 B 站账号信息。"""
+    try:
+        cookie = str(cfg.BILIBILI_MUSIC_CONFIG.get("cookie") or "")
+        logger.debug("B 站账号状态接口请求: %s", _cookie_debug_summary(cookie))
+        result = _bilibili_account_status(cookie)
+        if result.get("logged_in"):
+            logger.debug("B 站账号状态接口响应: logged_in=True %s", _debug_profile_text(result.get("profile")))
+        else:
+            logger.debug("B 站账号状态接口响应: logged_in=False message=%s", result.get("message", ""))
+        return JSONResponse(result)
+    except RequestsException as exc:
+        logger.warning("B 站账号状态查询失败: %s", exc)
+        return JSONResponse({"ok": True, "logged_in": False, "message": f"B 站 API 请求失败: {exc}"})
+    except Exception as exc:
+        logger.warning("B 站账号状态查询异常: %s", exc, exc_info=True)
+        return JSONResponse({"ok": True, "logged_in": False, "message": f"账号状态查询失败: {exc}"})
 
 
 @admin_router.post("/admin/api/config/reset")
@@ -748,8 +1588,57 @@ def admin_reset_config_overrides():
     web_player.reset_redis(force=True)
     web_player.reset_netease()
     _set_liked_ids_cache([])
+    try:
+        music_runtime = web_player.refresh_music_platforms()
+    except Exception as exc:
+        logger.debug("重置配置后刷新音乐平台失败: %s", exc)
+        music_runtime = {"available": False, "error": str(exc)}
     cfg.refresh_runtime_dependents({"redis", "web_player"})
-    return JSONResponse({"ok": True, "removed": True, "path": cfg.ADMIN_OVERRIDES_PATH})
+    return JSONResponse({"ok": True, "removed": True, "path": cfg.ADMIN_OVERRIDES_PATH, "music_platforms": music_runtime})
+
+
+def _parse_oopz_login_payload(body: dict[str, Any]) -> tuple[str, str, float]:
+    if not isinstance(body, dict):
+        body = {}
+    phone = str(body.get("phone", "") or "").strip()
+    password = str(body.get("password", "") or "")
+    try:
+        timeout = float(body.get("timeout", 90) or 90)
+    except (TypeError, ValueError):
+        timeout = 90.0
+    return phone, password, max(30.0, min(timeout, 180.0))
+
+
+def _client_safe_oopz_login_result(result: dict[str, Any]) -> dict[str, Any]:
+    """移除仅供服务端热更新用的原始凭据。"""
+    return {key: value for key, value in result.items() if key != "raw"}
+
+
+@admin_router.post("/admin/api/oopz/login")
+async def admin_oopz_login(request: Request):
+    if _oopz_login_lock.locked():
+        return JSONResponse({"ok": False, "error": "OOPZ 登录任务正在执行"}, status_code=409)
+
+    phone, password, timeout = _parse_oopz_login_payload(await request.json())
+
+    async with _oopz_login_lock:
+        try:
+            from oopz_password_login import OopzPasswordLoginError, login_with_password
+
+            result = await login_with_password(phone, password, timeout=timeout, headless=True, save=True)
+            raw_credentials = result.get("raw", {})
+            runtime = _refresh_oopz_runtime(raw_credentials)
+            saved = result.get("saved") or []
+            return JSONResponse({
+                **_client_safe_oopz_login_result(result),
+                "runtime": runtime,
+                "message": "OOPZ 登录成功，已保存到: " + ("、".join(saved) if saved else "运行时"),
+            })
+        except OopzPasswordLoginError as exc:
+            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
+        except Exception as exc:
+            logger.exception("后台 OOPZ 账号密码登录失败")
+            return JSONResponse({"ok": False, "error": f"OOPZ 登录失败: {exc}"}, status_code=500)
 
 
 def _parse_oopz_login_payload(body: dict[str, Any]) -> tuple[str, str, float]:

--- a/src/web_player_admin.py
+++ b/src/web_player_admin.py
@@ -1641,50 +1641,6 @@ async def admin_oopz_login(request: Request):
             return JSONResponse({"ok": False, "error": f"OOPZ 登录失败: {exc}"}, status_code=500)
 
 
-def _parse_oopz_login_payload(body: dict[str, Any]) -> tuple[str, str, float]:
-    if not isinstance(body, dict):
-        body = {}
-    phone = str(body.get("phone", "") or "").strip()
-    password = str(body.get("password", "") or "")
-    try:
-        timeout = float(body.get("timeout", 90) or 90)
-    except (TypeError, ValueError):
-        timeout = 90.0
-    return phone, password, max(30.0, min(timeout, 180.0))
-
-
-def _client_safe_oopz_login_result(result: dict[str, Any]) -> dict[str, Any]:
-    """移除仅供服务端热更新用的原始凭据。"""
-    return {key: value for key, value in result.items() if key != "raw"}
-
-
-@admin_router.post("/admin/api/oopz/login")
-async def admin_oopz_login(request: Request):
-    if _oopz_login_lock.locked():
-        return JSONResponse({"ok": False, "error": "OOPZ 登录任务正在执行"}, status_code=409)
-
-    phone, password, timeout = _parse_oopz_login_payload(await request.json())
-
-    async with _oopz_login_lock:
-        try:
-            from oopz_password_login import OopzPasswordLoginError, login_with_password
-
-            result = await login_with_password(phone, password, timeout=timeout, headless=True, save=True)
-            raw_credentials = result.get("raw", {})
-            runtime = _refresh_oopz_runtime(raw_credentials)
-            saved = result.get("saved") or []
-            return JSONResponse({
-                **_client_safe_oopz_login_result(result),
-                "runtime": runtime,
-                "message": "OOPZ 登录成功，已保存到: " + ("、".join(saved) if saved else "运行时"),
-            })
-        except OopzPasswordLoginError as exc:
-            return JSONResponse({"ok": False, "error": str(exc)}, status_code=400)
-        except Exception as exc:
-            logger.exception("后台 OOPZ 账号密码登录失败")
-            return JSONResponse({"ok": False, "error": f"OOPZ 登录失败: {exc}"}, status_code=500)
-
-
 @admin_router.get("/admin/api/overview")
 def admin_overview():
     return JSONResponse(_overview_payload(), headers={"Cache-Control": "no-store"})

--- a/tests/test_bilibili_music.py
+++ b/tests/test_bilibili_music.py
@@ -1,0 +1,121 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+try:
+    import requests
+    _REQUESTS_ERROR = None
+except Exception as exc:
+    _REQUESTS_ERROR = exc
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class BilibiliMusicTest(unittest.TestCase):
+    def setUp(self) -> None:
+        if _REQUESTS_ERROR is not None:
+            self.skipTest(f"缺少 requests 依赖: {_REQUESTS_ERROR}")
+        import bilibili_music
+
+        self.module = bilibili_music
+        self._old_config = bilibili_music._cached_config
+        bilibili_music._cached_config = {
+            "enabled": True,
+            "cookie": "SESSDATA=sess; bili_jct=csrf",
+        }
+
+    def tearDown(self) -> None:
+        self.module._cached_config = self._old_config
+
+    def test_video_playurl_uses_cid_from_view(self) -> None:
+        bili = self.module.BilibiliMusic()
+        calls = []
+
+        def fake_get(url, params=None, referer=None):
+            calls.append((url, params or {}, referer))
+            if url == self.module._API_VIDEO_VIEW:
+                return {
+                    "code": 0,
+                    "data": {
+                        "pages": [{"cid": 998877}],
+                    },
+                }
+            if url == self.module._API_VIDEO_PLAYURL:
+                self.assertEqual((params or {}).get("bvid"), "BV1test")
+                self.assertEqual((params or {}).get("cid"), "998877")
+                return {
+                    "code": 0,
+                    "data": {
+                        "dash": {
+                            "audio": [
+                                {"baseUrl": "https://low.example/audio.m4s", "bandwidth": 64000},
+                                {"baseUrl": "https://high.example/audio.m4s", "bandwidth": 128000},
+                            ],
+                        },
+                    },
+                }
+            return {"code": -1}
+
+        bili._get = fake_get
+
+        url = bili._get_video_audio_url("BV1test")
+
+        self.assertEqual(url, "https://high.example/audio.m4s")
+        self.assertEqual(calls[0][0], self.module._API_VIDEO_VIEW)
+        self.assertEqual(calls[1][0], self.module._API_VIDEO_PLAYURL)
+
+    def test_get_retries_once_after_412(self) -> None:
+        bili = self.module.BilibiliMusic()
+        target_url = "https://api.bilibili.com/x/web-interface/search/type"
+        calls = []
+
+        class FakeCookies(dict):
+            pass
+
+        class FakeSession:
+            def __init__(self):
+                self.headers = {}
+                self.cookies = FakeCookies()
+                self.target_calls = 0
+
+            def get(self, url, params=None, headers=None, timeout=10):
+                calls.append(url)
+                if url == self.module._BILIBILI_HOME:
+                    self.cookies["buvid3"] = "seed"
+                    return _FakeResponse(200, {"ok": True})
+                self.target_calls += 1
+                if self.target_calls == 1:
+                    return _FakeResponse(412, {"code": -412})
+                return _FakeResponse(200, {"code": 0, "data": {"result": []}})
+
+        fake_session = FakeSession()
+        fake_session.module = self.module
+        bili._session = fake_session
+
+        data = bili._get(target_url, params={"keyword": "测试"})
+
+        self.assertEqual(data["code"], 0)
+        self.assertEqual(calls, [target_url, self.module._BILIBILI_HOME, target_url])
+        self.assertEqual(fake_session.cookies["buvid3"], "seed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_music_modes.py
+++ b/tests/test_music_modes.py
@@ -174,7 +174,11 @@ class MusicModeTest(unittest.TestCase):
             "user-1",
         )
 
-        platform.get_song_url.assert_called_once_with(1)
+        platform.get_song_url.assert_called_once_with(
+            1,
+            expected_duration_ms=222000,
+            song_name="稻香",
+        )
         platform.summarize_by_id.assert_not_called()
         committed_song = self.handler._commit_song_request.call_args.args[0]
         self.assertEqual(committed_song["url"], "https://example.com/song.mp3")

--- a/tests/test_netease_cookie_playback.py
+++ b/tests/test_netease_cookie_playback.py
@@ -1,0 +1,133 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+try:
+    import requests
+    _REQUESTS_ERROR = None
+except Exception as exc:
+    _REQUESTS_ERROR = exc
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class NeteaseCookiePlaybackTest(unittest.TestCase):
+    def setUp(self) -> None:
+        if _REQUESTS_ERROR is not None:
+            self.skipTest(f"缺少 requests 依赖: {_REQUESTS_ERROR}")
+        self._old_config_module = sys.modules.get("config")
+        self._old_netease_module = sys.modules.get("netease")
+        fake_config = types.ModuleType("config")
+        fake_config.NETEASE_CLOUD = {
+            "base_url": "http://netease.example",
+            "cookie": "MUSIC_U=abc",
+            "audio_quality": "exhigh",
+        }
+        sys.modules["config"] = fake_config
+        sys.modules.pop("netease", None)
+        import netease
+
+        self.module = netease
+
+    def tearDown(self) -> None:
+        sys.modules.pop("netease", None)
+        if self._old_netease_module is not None:
+            sys.modules["netease"] = self._old_netease_module
+        if self._old_config_module is not None:
+            sys.modules["config"] = self._old_config_module
+        else:
+            sys.modules.pop("config", None)
+
+    def _client(self, session):
+        client = self.module.NeteaseCloud.__new__(self.module.NeteaseCloud)
+        client.base_url = "http://netease.example"
+        client.cookie = "MUSIC_U=abc"
+        client._session = session
+        client._last_song_url_error = ""
+        return client
+
+    def test_get_song_url_posts_cookie_in_body_before_get(self) -> None:
+        calls = []
+
+        class FakeSession:
+            def post(self, url, data=None, headers=None, timeout=10):
+                calls.append(("POST", url, data or {}, headers or {}))
+                return _FakeResponse({
+                    "code": 200,
+                    "data": [{
+                        "id": 1,
+                        "url": "https://music.example/full.mp3",
+                        "time": 222000,
+                        "size": 8_000_000,
+                    }],
+                })
+
+            def get(self, url, params=None, headers=None, timeout=10):
+                calls.append(("GET", url, params or {}, headers or {}))
+                return _FakeResponse({"code": 500, "data": []})
+
+        client = self._client(FakeSession())
+
+        url = client.get_song_url(1, expected_duration_ms=222000, song_name="稻香")
+
+        self.assertEqual(url, "https://music.example/full.mp3")
+        self.assertEqual(len(calls), 1)
+        method, request_url, data, headers = calls[0]
+        self.assertEqual(method, "POST")
+        self.assertEqual(request_url, "http://netease.example/song/url/v1")
+        self.assertEqual(data["id"], 1)
+        self.assertEqual(data["level"], "exhigh")
+        self.assertEqual(data["cookie"], "MUSIC_U=abc")
+        self.assertEqual(headers["Cookie"], "MUSIC_U=abc")
+
+    def test_get_song_url_rejects_free_trial_audio(self) -> None:
+        class FakeSession:
+            def __init__(self):
+                self.calls = []
+
+            def post(self, url, data=None, headers=None, timeout=10):
+                self.calls.append(("POST", url, data or {}))
+                return _FakeResponse({
+                    "code": 200,
+                    "data": [{
+                        "id": 2,
+                        "url": "https://music.example/trial.mp3",
+                        "time": 30040,
+                        "size": 600_000,
+                        "freeTrialInfo": {"start": 0, "end": 30},
+                    }],
+                })
+
+            def get(self, url, params=None, headers=None, timeout=10):
+                self.calls.append(("GET", url, params or {}))
+                return _FakeResponse({"code": 200, "data": [{"id": 2, "url": None}]})
+
+        session = FakeSession()
+        client = self._client(session)
+
+        url = client.get_song_url(2, expected_duration_ms=240000, song_name="会员歌")
+
+        self.assertIsNone(url)
+        self.assertIn("试听音频", client.last_song_url_error)
+        self.assertGreaterEqual(len(session.calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_player_admin.py
+++ b/tests/test_web_player_admin.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 try:
     from fastapi.testclient import TestClient
     _TESTCLIENT_ERROR = None
-except Exception as exc:
+except Exception as exc:  # pragma: no cover - 依赖缺失时跳过
     TestClient = None
     _TESTCLIENT_ERROR = exc
 

--- a/tests/test_web_player_admin.py
+++ b/tests/test_web_player_admin.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 try:
     from fastapi.testclient import TestClient
     _TESTCLIENT_ERROR = None
-except Exception as exc:  # pragma: no cover - 依赖缺失时跳过
+except Exception as exc:
     TestClient = None
     _TESTCLIENT_ERROR = exc
 
@@ -53,6 +53,19 @@ class _FakePlugins:
         return "data/plugin_runtime_state.json"
 
 
+class _FakeNeteaseResponse:
+    def __init__(self, payload, headers=None, cookies=None):
+        self._payload = payload
+        self.headers = headers or {}
+        self.cookies = cookies or []
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
 class WebPlayerAdminTest(unittest.TestCase):
     def setUp(self) -> None:
         if TestClient is None:
@@ -85,6 +98,218 @@ class WebPlayerAdminTest(unittest.TestCase):
         self.assertTrue(data["ok"])
         self.assertEqual(data["enabled_plugins"], ["alpha"])
         self.assertEqual(data["plugins"][0]["name"], "alpha")
+
+    def test_netease_qr_login_returns_qr_image_when_logged_in(self) -> None:
+        calls = []
+
+        def fake_get(base_url, path, params=None, **_kwargs):
+            calls.append((base_url, path, params or {}))
+            if path == "/login/qr/key":
+                payload = {"code": 200, "data": {"unikey": "qr-key"}}
+                return payload, _FakeNeteaseResponse(payload)
+            if path == "/login/qr/create":
+                self.assertEqual((params or {}).get("key"), "qr-key")
+                self.assertEqual((params or {}).get("qrimg"), "true")
+                payload = {
+                    "code": 200,
+                    "data": {
+                        "qrimg": "data:image/png;base64,abc",
+                        "qrurl": "orpheus://qr",
+                    },
+                }
+                return payload, _FakeNeteaseResponse(payload)
+            raise AssertionError(f"unexpected path: {path}")
+
+        with (
+            patch.object(self.module, "_admin_enabled", return_value=True),
+            patch.object(self.module, "_is_admin_authorized", return_value=True),
+            patch("web_player_admin._netease_api_get", side_effect=fake_get),
+        ):
+            response = self.client.post(
+                "/admin/api/netease/login/qr",
+                json={"base_url": "http://localhost:3000/"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["key"], "qr-key")
+        self.assertEqual(data["qrimg"], "data:image/png;base64,abc")
+        self.assertEqual(calls[0][:2], ("http://localhost:3000", "/login/qr/key"))
+        self.assertEqual(calls[1][:2], ("http://localhost:3000", "/login/qr/create"))
+
+    def test_netease_qr_check_returns_cookie_and_profile_on_success(self) -> None:
+        def fake_get(base_url, path, params=None, **_kwargs):
+            self.assertEqual(base_url, "http://localhost:3000")
+            self.assertEqual(path, "/login/qr/check")
+            self.assertEqual((params or {}).get("key"), "qr-key")
+            payload = {
+                "code": 200,
+                "data": {
+                    "code": 803,
+                    "message": "授权登录成功",
+                    "cookie": "MUSIC_U=abc; __csrf=def",
+                },
+            }
+            return payload, _FakeNeteaseResponse(payload)
+
+        def fake_post(base_url, path, data=None, **kwargs):
+            self.assertEqual(base_url, "http://localhost:3000")
+            self.assertEqual(path, "/login/status")
+            self.assertEqual((kwargs.get("headers") or {}).get("Cookie"), "MUSIC_U=abc; __csrf=def")
+            self.assertEqual((data or {}).get("cookie"), "MUSIC_U=abc; __csrf=def")
+            payload = {
+                "code": 200,
+                "data": {"profile": {"userId": 12345, "nickname": "测试账号"}},
+            }
+            return payload, _FakeNeteaseResponse(payload)
+
+        with (
+            patch.object(self.module, "_admin_enabled", return_value=True),
+            patch.object(self.module, "_is_admin_authorized", return_value=True),
+            patch("web_player_admin._netease_api_get", side_effect=fake_get),
+            patch("web_player_admin._netease_api_post", side_effect=fake_post),
+        ):
+            response = self.client.post(
+                "/admin/api/netease/login/qr/check",
+                json={"base_url": "http://localhost:3000", "key": "qr-key"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["cookie"], "MUSIC_U=abc; __csrf=def")
+        self.assertEqual(data["profile"]["user_id"], "12345")
+        self.assertEqual(data["profile"]["nickname"], "测试账号")
+
+    def test_netease_account_endpoint_returns_current_profile(self) -> None:
+        def fake_post(base_url, path, data=None, **kwargs):
+            self.assertEqual(base_url, "http://localhost:3000")
+            self.assertEqual(path, "/login/status")
+            self.assertEqual((kwargs.get("headers") or {}).get("Cookie"), "MUSIC_U=abc")
+            self.assertEqual((data or {}).get("cookie"), "MUSIC_U=abc")
+            payload = {
+                "code": 200,
+                "data": {"profile": {"userId": 67890, "nickname": "已保存账号"}},
+            }
+            return payload, _FakeNeteaseResponse(payload)
+
+        with (
+            patch.object(self.module, "_admin_enabled", return_value=True),
+            patch.object(self.module, "_is_admin_authorized", return_value=True),
+            patch("web_player_admin.cfg.NETEASE_CLOUD", {"base_url": "http://localhost:3000", "cookie": "MUSIC_U=abc"}),
+            patch("web_player_admin._netease_api_post", side_effect=fake_post),
+        ):
+            response = self.client.get("/admin/api/netease/account")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["ok"])
+        self.assertTrue(data["logged_in"])
+        self.assertEqual(data["profile"]["user_id"], "67890")
+        self.assertEqual(data["profile"]["nickname"], "已保存账号")
+
+    def test_bilibili_qr_login_returns_qr_image_when_logged_in(self) -> None:
+        def fake_get(path, params=None):
+            self.assertEqual(path, "/x/passport-login/web/qrcode/generate")
+            payload = {
+                "code": 0,
+                "data": {
+                    "qrcode_key": "bili-key",
+                    "url": "https://passport.bilibili.com/h5-app/passport/login/scan?qrcode_key=bili-key",
+                },
+            }
+            return payload, _FakeNeteaseResponse(payload)
+
+        with (
+            patch.object(self.module, "_admin_enabled", return_value=True),
+            patch.object(self.module, "_is_admin_authorized", return_value=True),
+            patch("web_player_admin._bilibili_api_get", side_effect=fake_get),
+            patch("web_player_admin._make_qr_data_uri", return_value="data:image/png;base64,bili"),
+        ):
+            response = self.client.post("/admin/api/bilibili/login/qr", json={})
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["key"], "bili-key")
+        self.assertEqual(data["qrimg"], "data:image/png;base64,bili")
+
+    def test_bilibili_qr_check_returns_cookie_and_profile_on_success(self) -> None:
+        def fake_get(path, params=None):
+            self.assertEqual(path, "/x/passport-login/web/qrcode/poll")
+            self.assertEqual((params or {}).get("qrcode_key"), "bili-key")
+            payload = {
+                "code": 0,
+                "data": {
+                    "code": 0,
+                    "message": "扫描登录成功",
+                    "url": (
+                        "https://passport.bilibili.com/crossDomain?"
+                        "DedeUserID=100&DedeUserID__ckMd5=md5&SESSDATA=sess&"
+                        "bili_jct=csrf&sid=abc"
+                    ),
+                },
+            }
+            return payload, _FakeNeteaseResponse(payload)
+
+        with (
+            patch.object(self.module, "_admin_enabled", return_value=True),
+            patch.object(self.module, "_is_admin_authorized", return_value=True),
+            patch("web_player_admin._bilibili_api_get", side_effect=fake_get),
+            patch("web_player_admin._bilibili_account_status", return_value={
+                "ok": True,
+                "logged_in": True,
+                "profile": {"user_id": "100", "nickname": "B站测试账号"},
+            }),
+        ):
+            response = self.client.post(
+                "/admin/api/bilibili/login/qr/check",
+                json={"key": "bili-key"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["status"], "success")
+        self.assertEqual(
+            data["cookie"],
+            "SESSDATA=sess; bili_jct=csrf; DedeUserID=100; DedeUserID__ckMd5=md5; sid=abc",
+        )
+        self.assertEqual(data["profile"]["user_id"], "100")
+        self.assertEqual(data["profile"]["nickname"], "B站测试账号")
+
+    def test_bilibili_account_endpoint_returns_current_profile(self) -> None:
+        def fake_get(path, headers=None):
+            self.assertEqual(path, "/x/web-interface/nav")
+            self.assertEqual((headers or {}).get("Cookie"), "SESSDATA=sess")
+            payload = {
+                "code": 0,
+                "message": "0",
+                "data": {
+                    "isLogin": True,
+                    "mid": 24680,
+                    "uname": "已保存B站账号",
+                    "face": "https://i0.hdslb.com/face.jpg",
+                },
+            }
+            return payload, _FakeNeteaseResponse(payload)
+
+        with (
+            patch.object(self.module, "_admin_enabled", return_value=True),
+            patch.object(self.module, "_is_admin_authorized", return_value=True),
+            patch("web_player_admin.cfg.BILIBILI_MUSIC_CONFIG", {"enabled": True, "cookie": "SESSDATA=sess"}),
+            patch("web_player_admin._bilibili_account_api_get", side_effect=fake_get),
+        ):
+            response = self.client.get("/admin/api/bilibili/account")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["ok"])
+        self.assertTrue(data["logged_in"])
+        self.assertEqual(data["profile"]["user_id"], "24680")
+        self.assertEqual(data["profile"]["nickname"], "已保存B站账号")
 
     def test_admin_html_pages_reference_shared_shell_assets(self) -> None:
         paths = [


### PR DESCRIPTION
## 变更说明

本次 PR 补充网易云音乐和 B 站的扫码登录、Cookie 自动保存、账号信息展示逻辑，并修复点歌播放链路中 Cookie 使用不完整导致的播放失败或 30 秒试听问题。

## 主要改动

- 新增网易云音乐扫码登录流程，支持二维码生成、轮询登录状态、自动提取并保存 Cookie。
- 新增 B 站扫码登录流程，支持二维码生成、扫码确认、Cookie 提取保存。
- 后台配置页展示已登录账号昵称、ID 等状态信息。
- 配置更新后刷新运行中的音乐平台实例，让新 Cookie 立即生效。
- 修复 B 站搜索接口偶发 HTTP 412：
  - 补全浏览器请求头。
  - 使用 requests.Session 维护 Cookie。
  - 遇到 412 时先访问 B 站首页刷新 Cookie，再自动重试一次。
- 修复 B 站视频播放链接获取：
  - 先通过视频详情获取 cid。
  - 再使用 bvid + cid 请求 DASH 音频流。
- 修复网易云会员歌曲播放链路：
  - /song/url/v1 优先使用 POST。
  - 同时在请求头和 body 中传递 Cookie。
  - 识别 freeTrialInfo 和 30 秒试听音频，避免把试听链接当完整歌曲播放。
- 点歌和后台加歌时传入歌曲名、标称时长，提升试听链接判断准确性。