### PR TITLE
重构后台管理 UI：内联事件处理器全量迁移到事件委托

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -267,6 +267,7 @@ ONEBOT_V11_CONFIG = {
 AUTO_RECALL_CONFIG = {
     "enabled": False,
     "delay": 30,                   # 自动撤回延迟（秒）
+    "max_pending": 1000,           # 最多等待撤回的消息数，防止刷屏时占用过多内存
     "exclude_commands": [          # 不自动撤回的命令类型
         "ai_chat",                 # AI 聊天回复
         "ai_image",                # AI 生成图片

--- a/src/app/lifecycle/shutdown_coordinator.py
+++ b/src/app/lifecycle/shutdown_coordinator.py
@@ -24,6 +24,11 @@ class ShutdownCoordinator:
                 scheduler.reminder.stop()
             except Exception as exc:
                 logger.warning("停止定时服务时出现异常: %s", exc)
+            try:
+                recall_scheduler = context.handler.services.safety.recall_scheduler
+                recall_scheduler.stop()
+            except Exception as exc:
+                logger.warning("停止自动撤回调度时出现异常: %s", exc)
 
         try:
             from core.database import MessageStatsDB

--- a/src/app/services/safety/message_recall_scheduler.py
+++ b/src/app/services/safety/message_recall_scheduler.py
@@ -1,8 +1,24 @@
+import heapq
 import threading
+import time
+from dataclasses import dataclass, field
 from typing import Optional
 
 from config import AUTO_RECALL_CONFIG
 from app.services.runtime import CommandRuntimeView, sender_of
+from core.logger_config import get_logger
+
+logger = get_logger("MessageRecallScheduler")
+
+
+@dataclass(order=True)
+class _ScheduledRecall:
+    due_at: float
+    sequence: int
+    message_id: str = field(compare=False)
+    channel: str = field(compare=False)
+    area: str = field(compare=False)
+    timestamp: str = field(compare=False, default="")
 
 
 class MessageRecallScheduler:
@@ -10,8 +26,12 @@ class MessageRecallScheduler:
 
     def __init__(self, runtime: CommandRuntimeView):
         self._sender = sender_of(runtime)
-        self._pending_timers: list[threading.Timer] = []
         self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._pending: list[_ScheduledRecall] = []
+        self._worker: threading.Thread | None = None
+        self._sequence = 0
+        self._stopped = False
 
     @staticmethod
     def should_skip_auto_recall(command_type: str) -> Optional[bool]:
@@ -39,27 +59,90 @@ class MessageRecallScheduler:
         if delay <= 0:
             return
 
-        def _do_recall():
-            self._sender.recall_message(
-                message_id=message_id, area=area,
-                channel=channel, timestamp=timestamp,
-            )
-            with self._lock:
-                self._pending_timers = [t for t in self._pending_timers if t.is_alive()]
-
-        timer = threading.Timer(delay, _do_recall)
-        timer.daemon = True
         with self._lock:
-            self._pending_timers.append(timer)
-        timer.start()
+            max_pending = self._max_pending()
+            if len(self._pending) >= max_pending:
+                logger.warning(
+                    "自动撤回待处理任务已满 (%d)，跳过 message_id=%s",
+                    max_pending,
+                    str(message_id)[:16],
+                )
+                return
+
+            self._sequence += 1
+            heapq.heappush(
+                self._pending,
+                _ScheduledRecall(
+                    due_at=time.monotonic() + float(delay),
+                    sequence=self._sequence,
+                    message_id=message_id,
+                    channel=channel,
+                    area=area,
+                    timestamp=timestamp,
+                ),
+            )
+            self._ensure_worker_locked()
+            self._condition.notify()
 
     def cancel_all(self) -> int:
-        """取消所有待执行的撤回计时器，返回取消数量。"""
+        """取消所有待执行的撤回任务，返回取消数量。"""
         with self._lock:
-            count = 0
-            for t in self._pending_timers:
-                if t.is_alive():
-                    t.cancel()
-                    count += 1
-            self._pending_timers.clear()
+            count = len(self._pending)
+            self._pending.clear()
+            self._condition.notify()
         return count
+
+    def stop(self) -> int:
+        """停止后台调度线程，并取消所有待执行任务。"""
+        with self._lock:
+            count = len(self._pending)
+            self._pending.clear()
+            self._stopped = True
+            self._condition.notify_all()
+            worker = self._worker
+        if worker and worker.is_alive():
+            worker.join(timeout=3)
+        return count
+
+    @staticmethod
+    def _max_pending() -> int:
+        try:
+            return max(1, int(AUTO_RECALL_CONFIG.get("max_pending", 1000) or 1000))
+        except (TypeError, ValueError):
+            return 1000
+
+    def _ensure_worker_locked(self) -> None:
+        if self._worker and self._worker.is_alive():
+            return
+        self._stopped = False
+        self._worker = threading.Thread(
+            target=self._worker_loop,
+            name="MessageRecallScheduler",
+            daemon=True,
+        )
+        self._worker.start()
+
+    def _worker_loop(self) -> None:
+        while True:
+            with self._lock:
+                while not self._stopped and not self._pending:
+                    self._condition.wait()
+                if self._stopped:
+                    return
+
+                job = self._pending[0]
+                wait_seconds = job.due_at - time.monotonic()
+                if wait_seconds > 0:
+                    self._condition.wait(timeout=wait_seconds)
+                    continue
+                heapq.heappop(self._pending)
+
+            try:
+                self._sender.recall_message(
+                    message_id=job.message_id,
+                    area=job.area,
+                    channel=job.channel,
+                    timestamp=job.timestamp,
+                )
+            except Exception:
+                logger.warning("自动撤回执行失败: message_id=%s", str(job.message_id)[:16], exc_info=True)

--- a/src/oopz/oopz_password_login.py
+++ b/src/oopz/oopz_password_login.py
@@ -628,8 +628,18 @@ def login_with_api_password(
 
 
 def _config_login_account(oopz_config: Mapping[str, Any]) -> tuple[str, str]:
-    phone = os.environ.get("OOPZ_PHONE") or oopz_config.get("login_phone") or ""
-    password = os.environ.get("OOPZ_PASSWORD") or oopz_config.get("login_password") or ""
+    phone = (
+        os.environ.get("OOPZ_PHONE")
+        or oopz_config.get("login_phone")
+        or oopz_config.get("phone")
+        or ""
+    )
+    password = (
+        os.environ.get("OOPZ_PASSWORD")
+        or oopz_config.get("login_password")
+        or oopz_config.get("password")
+        or ""
+    )
     return str(phone).strip(), str(password or "")
 
 

--- a/src/oopz/oopz_sender.py
+++ b/src/oopz/oopz_sender.py
@@ -124,6 +124,7 @@ class OopzSender(UploadMixin, OopzApiMixin):
 
     # 全局速率限制: 最小请求间隔 (秒), 即 1/max_rps
     _RATE_LIMIT_INTERVAL = 0.35  # ~3 req/s
+    _AUTH_REFRESH_STATUSES = {401, 403, 428}
 
     def __init__(self):
         self.signer = Signer()
@@ -134,6 +135,7 @@ class OopzSender(UploadMixin, OopzApiMixin):
         self._area_members_stale_ttl = 300.0
         self._cache_max_entries = 200
         self._rate_lock = threading.Lock()
+        self._auth_refresh_lock = threading.Lock()
         self._last_request_time = 0.0
         # 代理：留空/不设=使用系统代理(HTTP_PROXY/HTTPS_PROXY)；False 或 "direct"=直连；或 "http://ip:port"
         proxy_settings = configure_requests_session(self.session, OOPZ_CONFIG.get("proxy"))
@@ -159,7 +161,7 @@ class OopzSender(UploadMixin, OopzApiMixin):
 
     # ---- 内部 ----
 
-    def _request(self, method: str, url_path: str, body: dict | None = None) -> requests.Response:
+    def _signed_request_once(self, method: str, url_path: str, body: dict | None = None) -> requests.Response:
         """统一处理带签名的 HTTP 请求（POST/PUT/DELETE）。"""
         self._throttle()
         if body is not None:
@@ -176,6 +178,51 @@ class OopzSender(UploadMixin, OopzApiMixin):
         url = OOPZ_CONFIG["base_url"] + url_path
         return self.session.request(method, url, headers=headers, data=data)
 
+    def _refresh_credentials_after_auth_failure(self, status_code: int) -> bool:
+        with self._auth_refresh_lock:
+            try:
+                from oopz.oopz_password_login import (
+                    OopzPasswordLoginError,
+                    load_private_key_from_pem,
+                    refresh_credentials_from_config_password,
+                )
+
+                credentials = refresh_credentials_from_config_password(timeout=20, save=True)
+            except OopzPasswordLoginError as exc:
+                logger.warning("OOPZ 登录态失效，自动刷新失败，继续使用现有凭据: HTTP %s, %s", status_code, exc)
+                return False
+            except Exception as exc:
+                logger.warning("OOPZ 登录态失效，自动刷新异常，继续使用现有凭据: HTTP %s, %s", status_code, exc, exc_info=True)
+                return False
+
+            if not credentials:
+                logger.warning(
+                    "OOPZ 登录态失效: HTTP %s。未配置 login_phone/login_password 或 phone/password，无法自动刷新凭据。",
+                    status_code,
+                )
+                return False
+
+            pem = str(credentials.get("private_key_pem") or "").strip()
+            if pem:
+                try:
+                    self.signer.private_key = load_private_key_from_pem(pem)
+                except Exception as exc:
+                    logger.warning("OOPZ 登录态已刷新，但更新签名私钥失败: %s", exc, exc_info=True)
+                    return False
+
+            cache = getattr(self, "_area_members_cache", None)
+            if isinstance(cache, dict):
+                cache.clear()
+            logger.info("OOPZ 登录态已自动刷新，正在重试刚才失败的请求")
+            return True
+
+    def _request(self, method: str, url_path: str, body: dict | None = None) -> requests.Response:
+        """统一处理带签名的 HTTP 请求（POST/PUT/DELETE）。"""
+        resp = self._signed_request_once(method, url_path, body)
+        if resp.status_code in self._AUTH_REFRESH_STATUSES and self._refresh_credentials_after_auth_failure(resp.status_code):
+            resp = self._signed_request_once(method, url_path, body)
+        return resp
+
     def _post(self, url_path: str, body: dict) -> requests.Response:
         return self._request("POST", url_path, body)
 
@@ -186,7 +233,7 @@ class OopzSender(UploadMixin, OopzApiMixin):
         """DELETE 请求，部分撤回接口可能用 DELETE 方法"""
         return self._request("DELETE", url_path, body)
 
-    def _get(self, url_path: str, params: Optional[dict] = None) -> requests.Response:
+    def _get_once(self, url_path: str, params: Optional[dict] = None) -> requests.Response:
         """GET 请求（签名包含查询参数）。"""
         self._throttle()
         if params:
@@ -198,6 +245,13 @@ class OopzSender(UploadMixin, OopzApiMixin):
         headers = {**self.session.headers, **self.signer.oopz_headers(sign_path, "")}
         url = OOPZ_CONFIG["base_url"] + url_path
         return self.session.get(url, headers=headers, params=params, timeout=10)
+
+    def _get(self, url_path: str, params: Optional[dict] = None) -> requests.Response:
+        """GET 请求（签名包含查询参数）。"""
+        resp = self._get_once(url_path, params=params)
+        if resp.status_code in self._AUTH_REFRESH_STATUSES and self._refresh_credentials_after_auth_failure(resp.status_code):
+            resp = self._get_once(url_path, params=params)
+        return resp
 
     # ---- 发送消息 ----
 

--- a/src/web/admin/shared.py
+++ b/src/web/admin/shared.py
@@ -781,13 +781,15 @@ def _load_admin_template() -> string.Template:
     return _ADMIN_SHELL_TEMPLATE
 
 
-_ADMIN_PAGES: dict[str, dict[str, str]] = {
+_ADMIN_PAGES: dict[str, dict[str, Any]] = {
     "dashboard": {
         "page_title": "后台总览",
         "page_id": "dashboard",
         "brand_title": "后台管理",
         "brand_copy": "顶部主导航、数据优先、专业 SaaS 工作台。",
-        "topbar_actions": '<button class="btn btn-ghost" type="button" onclick="loadOverview().catch(() => {})">刷新概览</button>',
+        "topbar_actions": [
+            {"action": "refresh-overview", "label": "刷新概览"},
+        ],
         "login_title": "登录后台总览",
         "login_copy": "登录后查看实时状态与关键指标。",
         "login_button": "进入总览",
@@ -797,7 +799,9 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "music",
         "brand_title": "音乐管理",
         "brand_copy": "把播放控制、搜索加歌和队列调度整理成标准运营面板。",
-        "topbar_actions": '<button class="btn btn-ghost" type="button" onclick="loadQueue().catch(() => {})">刷新队列</button>',
+        "topbar_actions": [
+            {"action": "refresh-queue", "label": "刷新队列"},
+        ],
         "login_title": "登录音乐后台",
         "login_copy": "登录后控制播放、搜索歌曲和调整队列。",
         "login_button": "进入音乐控制台",
@@ -807,10 +811,11 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "config",
         "brand_title": "配置中心",
         "brand_copy": "把长表单整理成章节化配置工作台，保留原字段和保存接口。",
-        "topbar_actions": (
-            '<button class="btn btn-ghost" type="button" onclick="loadConfig().catch(() => {})">刷新配置</button>\n'
-            '          <button class="btn btn-primary" type="button" onclick="saveConfig(true)">保存并立即生效</button>'
-        ),
+        "topbar_actions": [
+            {"action": "refresh-config", "label": "刷新配置"},
+            {"action": "reset-overrides", "label": "恢复运行配置"},
+            {"action": "save-config", "label": "保存并立即生效", "variant": "primary"},
+        ],
         "login_title": "登录配置中心",
         "login_copy": "登录后调整后台配置。",
         "login_button": "进入配置中心",
@@ -820,10 +825,10 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "stats",
         "brand_title": "统计页",
         "brand_copy": "让摘要、榜单和危险操作形成稳定阅读顺序，而不是只摆一张表。",
-        "topbar_actions": (
-            '<button class="btn btn-ghost" type="button" onclick="loadTop().catch(() => {})">刷新统计</button>\n'
-            '          <button class="btn btn-danger" type="button" onclick="clearHistory()">清空历史</button>'
-        ),
+        "topbar_actions": [
+            {"action": "refresh-stats", "label": "刷新统计"},
+            {"action": "clear-history", "label": "清空历史", "variant": "danger"},
+        ],
         "login_title": "登录统计页",
         "login_copy": "登录后查看最近 7 天的播放排行。",
         "login_button": "进入统计页",
@@ -833,10 +838,10 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "system",
         "brand_title": "系统页",
         "brand_copy": "把播放器入口、系统快照和实时日志拆成明确的运维层级。",
-        "topbar_actions": (
-            '<button class="btn btn-ghost" type="button" onclick="loadSys().catch(() => {})">刷新系统信息</button>\n'
-            '          <button class="btn btn-ghost" type="button" onclick="loadLogs(logTailSize).catch(() => {})">刷新日志</button>'
-        ),
+        "topbar_actions": [
+            {"action": "refresh-system", "label": "刷新系统信息"},
+            {"action": "refresh-logs", "label": "刷新日志"},
+        ],
         "login_title": "登录系统页",
         "login_copy": "登录后查看链接、系统信息和日志。",
         "login_button": "进入系统页",
@@ -846,7 +851,9 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "activity",
         "brand_title": "活跃统计",
         "brand_copy": "频道消息趋势与用户活跃排行一览。",
-        "topbar_actions": '<button class="btn btn-ghost" type="button" onclick="loadActivity().catch(() => {})">刷新统计</button>',
+        "topbar_actions": [
+            {"action": "refresh-activity", "label": "刷新统计"},
+        ],
         "login_title": "登录活跃统计",
         "login_copy": "登录后查看消息趋势与活跃排行。",
         "login_button": "进入活跃统计",
@@ -856,7 +863,9 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "scheduler",
         "brand_title": "定时任务",
         "brand_copy": "管理定时消息与用户提醒。",
-        "topbar_actions": '<button class="btn btn-ghost" type="button" onclick="loadScheduler().catch(() => {})">刷新列表</button>',
+        "topbar_actions": [
+            {"action": "refresh-scheduler", "label": "刷新列表"},
+        ],
         "login_title": "登录定时任务",
         "login_copy": "登录后管理定时消息与查看提醒。",
         "login_button": "进入定时任务",
@@ -866,7 +875,9 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "members",
         "brand_title": "成员管理",
         "brand_copy": "域成员浏览、管理操作与封禁列表。",
-        "topbar_actions": '<button class="btn btn-ghost" type="button" onclick="loadMembers().catch(() => {})">刷新成员</button>',
+        "topbar_actions": [
+            {"action": "refresh-members", "label": "刷新成员"},
+        ],
         "login_title": "登录成员管理",
         "login_copy": "登录后管理域成员。",
         "login_button": "进入成员管理",
@@ -876,7 +887,9 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "areas",
         "brand_title": "域管理",
         "brand_copy": "域配置、频道管理与语音频道监控。",
-        "topbar_actions": '<button class="btn btn-ghost" type="button" onclick="loadAreaManager().catch(() => {})">刷新</button>',
+        "topbar_actions": [
+            {"action": "refresh-areas", "label": "刷新"},
+        ],
         "login_title": "登录域管理",
         "login_copy": "登录后管理域配置与频道。",
         "login_button": "进入域管理",
@@ -886,7 +899,9 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "plugins",
         "brand_title": "插件管理",
         "brand_copy": "查看、加载、卸载插件，在线编辑插件配置。",
-        "topbar_actions": '<button class="btn btn-ghost" type="button" onclick="loadPlugins().catch(() => {})">刷新列表</button>',
+        "topbar_actions": [
+            {"action": "refresh-plugins", "label": "刷新列表"},
+        ],
         "login_title": "登录插件管理",
         "login_copy": "登录后管理插件与配置。",
         "login_button": "进入插件管理",
@@ -896,12 +911,27 @@ _ADMIN_PAGES: dict[str, dict[str, str]] = {
         "page_id": "setup",
         "brand_title": "系统体检",
         "brand_copy": "把首启检查、运行时诊断和下一步配置建议放在一个页面里。",
-        "topbar_actions": '<button class="btn btn-ghost" type="button" onclick="loadDiagnostics().catch(() => {})">重新体检</button>',
+        "topbar_actions": [
+            {"action": "refresh-diagnostics", "label": "重新体检"},
+        ],
         "login_title": "登录系统体检",
         "login_copy": "登录后查看系统体检与首启向导。",
         "login_button": "进入体检页",
     },
 }
+
+
+def _render_topbar_actions(actions: list[dict[str, str]]) -> str:
+    """把结构化按钮声明渲染成顶栏 HTML，行为通过 data-action 委托到页面脚本。"""
+    buttons = [
+        '<button class="btn btn-{variant}" type="button" data-action="{action}">{label}</button>'.format(
+            variant=action.get("variant", "ghost"),
+            action=action["action"],
+            label=action["label"],
+        )
+        for action in actions
+    ]
+    return "\n          ".join(buttons)
 
 
 def _render_admin_page(page_key: str) -> HTMLResponse:
@@ -922,7 +952,7 @@ def _render_admin_page(page_key: str) -> HTMLResponse:
         page_id=meta["page_id"],
         brand_title=meta["brand_title"],
         brand_copy=meta["brand_copy"],
-        topbar_actions=meta["topbar_actions"],
+        topbar_actions=_render_topbar_actions(meta["topbar_actions"]),
         login_title=meta["login_title"],
         login_copy=meta["login_copy"],
         login_button=meta["login_button"],

--- a/src/web/assets/admin/admin-shell-template.html
+++ b/src/web/assets/admin/admin-shell-template.html
@@ -22,7 +22,7 @@
         <div class="topbar-actions">
           <span id="topStatus" class="status-text is-warning">等待登录</span>
           $topbar_actions
-          <button class="btn" type="button" onclick="logout()">退出登录</button>
+          <button class="btn" type="button" data-action="logout">退出登录</button>
         </div>
       </div>
       <div class="topbar-nav-row">
@@ -45,7 +45,7 @@
           <div class="stack" style="margin-top: 24px;">
             <input id="pwd" type="password" placeholder="请输入后台密码" />
             <div class="action-row">
-              <button class="btn btn-primary" type="button" onclick="login()">$login_button</button>
+              <button class="btn btn-primary" type="button" data-action="login">$login_button</button>
             </div>
             <div id="loginMsg" class="msg"></div>
           </div>
@@ -57,7 +57,7 @@ $page_content
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
-  <script src="/admin-assets/admin-shell.js?v=10"></script>
+  <script src="/admin-assets/admin-shell.js?v=11"></script>
   <script>
 $page_script
   </script>

--- a/src/web/assets/admin/admin-shell-template.html
+++ b/src/web/assets/admin/admin-shell-template.html
@@ -57,7 +57,7 @@ $page_content
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
-  <script src="/admin-assets/admin-shell.js?v=11"></script>
+  <script src="/admin-assets/admin-shell.js?v=12"></script>
   <script>
 $page_script
   </script>

--- a/src/web/assets/admin/admin-shell-template.html
+++ b/src/web/assets/admin/admin-shell-template.html
@@ -57,7 +57,7 @@ $page_content
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
-  <script src="/admin-assets/admin-shell.js?v=9"></script>
+  <script src="/admin-assets/admin-shell.js?v=10"></script>
   <script>
 $page_script
   </script>

--- a/src/web/assets/admin/admin-shell.css
+++ b/src/web/assets/admin/admin-shell.css
@@ -500,6 +500,10 @@ thead th,
   align-items: start;
 }
 
+.config-layout--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .system-grid {
   grid-template-columns: minmax(320px, 0.9fr) minmax(0, 1.1fr);
 }

--- a/src/web/assets/admin/admin-shell.js
+++ b/src/web/assets/admin/admin-shell.js
@@ -598,6 +598,19 @@
   // -------------------------------------------------------------------------
 
   const _actionHandlers = Object.create(null);
+  // 内置动作：所有页面共用的弹窗关闭与登录/登出，免去逐页重复注册。
+  // login/logout 由各页脚本定义为全局函数，点击时已就绪。
+  _actionHandlers["close-modal"] = () => closeModal();
+  _actionHandlers["login"] = () => {
+    if (typeof window.login === "function") {
+      window.login();
+    }
+  };
+  _actionHandlers["logout"] = () => {
+    if (typeof window.logout === "function") {
+      window.logout();
+    }
+  };
 
   function registerActions(handlers) {
     Object.assign(_actionHandlers, handlers || {});

--- a/src/web/assets/admin/admin-shell.js
+++ b/src/web/assets/admin/admin-shell.js
@@ -36,7 +36,10 @@
     });
     const data = await response.json().catch(() => ({}));
     if (!response.ok || data.ok === false) {
-      throw new Error(data.error || ("HTTP " + response.status));
+      const detail = Array.isArray(data.errors) && data.errors.length > 0
+        ? data.errors.join(" | ")
+        : "";
+      throw new Error(data.error || detail || ("HTTP " + response.status));
     }
     return data;
   }
@@ -311,10 +314,6 @@
     });
   }
 
-  function bindHoverMotion() {
-    return;
-  }
-
   async function copyText(value) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       await navigator.clipboard.writeText(value);
@@ -335,7 +334,6 @@
     const settings = options || {};
     const currentPage = settings.page || document.body.dataset.adminPage || "";
     renderNav(currentPage);
-    bindHoverMotion();
     animateEnter();
     if (settings.passwordHandler) {
       bindEnterSubmit(settings.passwordId || "pwd", settings.passwordHandler);
@@ -498,15 +496,141 @@
       .replaceAll("'", "&#39;");
   }
 
+  // -------------------------------------------------------------------------
+  // Modal subsystem (shared dialog reused across admin pages)
+  // Pages must provide #modalOverlay / #modalDialog / #modalTitle /
+  // #modalBody / #modalFooter in their markup.
+  // -------------------------------------------------------------------------
+
+  let _modalCloseCb = null;
+
+  function _modalEls() {
+    return {
+      overlay: byId("modalOverlay"),
+      dialog: byId("modalDialog"),
+      title: byId("modalTitle"),
+      body: byId("modalBody"),
+      footer: byId("modalFooter"),
+    };
+  }
+
+  function openModal(title, bodyHtml, footerHtml, onClose) {
+    const els = _modalEls();
+    if (!els.dialog || !els.overlay) {
+      return els;
+    }
+    _modalCloseCb = typeof onClose === "function" ? onClose : null;
+    if (els.title) {
+      els.title.textContent = title || "";
+    }
+    if (els.body) {
+      els.body.innerHTML = bodyHtml || "";
+    }
+    if (els.footer) {
+      els.footer.innerHTML = footerHtml || "";
+    }
+    els.overlay.classList.add("is-open");
+    els.dialog.classList.add("is-open");
+    return els;
+  }
+
+  function closeModal() {
+    const els = _modalEls();
+    if (els.dialog) {
+      els.dialog.classList.remove("is-open");
+    }
+    if (els.overlay) {
+      els.overlay.classList.remove("is-open");
+    }
+    const cb = _modalCloseCb;
+    _modalCloseCb = null;
+    if (cb) {
+      cb();
+    }
+  }
+
+  function confirm(title, message, options) {
+    const opts = options || {};
+    return new Promise((resolve) => {
+      const els = _modalEls();
+      if (!els.dialog || !els.footer) {
+        resolve(false);
+        return;
+      }
+      let settled = false;
+      const done = (value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        closeModal();
+        resolve(value);
+      };
+      openModal(
+        title,
+        '<div class="m-confirm-text">' + (message || "") + "</div>",
+        null,
+        () => {
+          if (!settled) {
+            settled = true;
+            resolve(false);
+          }
+        }
+      );
+      els.footer.innerHTML = "";
+      const cancelBtn = document.createElement("button");
+      cancelBtn.className = "btn btn-ghost";
+      cancelBtn.textContent = opts.cancelText || "取消";
+      cancelBtn.addEventListener("click", () => done(false));
+      const okBtn = document.createElement("button");
+      okBtn.className = "btn " + (opts.danger === false ? "btn-primary" : "btn-danger");
+      okBtn.textContent = opts.okText || "确认";
+      okBtn.addEventListener("click", () => done(true));
+      els.footer.appendChild(cancelBtn);
+      els.footer.appendChild(okBtn);
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Action registry (data-action + event delegation)
+  // Pages register handlers by action key; topbar/page buttons carry only
+  // data-action so behavior stays in JS instead of inline onclick markup.
+  // -------------------------------------------------------------------------
+
+  const _actionHandlers = Object.create(null);
+
+  function registerActions(handlers) {
+    Object.assign(_actionHandlers, handlers || {});
+  }
+
+  document.addEventListener("click", (event) => {
+    const trigger = event.target.closest("[data-action]");
+    if (!trigger) {
+      return;
+    }
+    const handler = _actionHandlers[trigger.dataset.action];
+    if (!handler) {
+      return;
+    }
+    event.preventDefault();
+    Promise.resolve()
+      .then(() => handler(trigger, event))
+      .catch(() => {});
+  });
+
   window.AdminShell = {
     animateNumber,
     animatePanel,
     byId,
+    closeModal,
+    confirm,
     copyText,
     escapeHtml,
     flashUpdate,
     init,
+    openModal,
     refreshCustomSelect,
+    registerActions,
     req,
     setAuthState,
     setMicroStatus,

--- a/src/web/assets/admin/admin-shell.js
+++ b/src/web/assets/admin/admin-shell.js
@@ -616,19 +616,46 @@
     Object.assign(_actionHandlers, handlers || {});
   }
 
+  function _dispatch(trigger, key, event) {
+    const handler = _actionHandlers[key];
+    if (!handler) {
+      return;
+    }
+    Promise.resolve()
+      .then(() => handler(trigger, event))
+      .catch(() => {});
+  }
+
   document.addEventListener("click", (event) => {
     const trigger = event.target.closest("[data-action]");
     if (!trigger) {
       return;
     }
-    const handler = _actionHandlers[trigger.dataset.action];
-    if (!handler) {
+    event.preventDefault();
+    _dispatch(trigger, trigger.dataset.action, event);
+  });
+
+  // 委托 change 事件：select / checkbox 用 data-change 指定动作键，
+  // 处理函数从入参 el 读取 .value / .checked。
+  document.addEventListener("change", (event) => {
+    const trigger = event.target.closest("[data-change]");
+    if (!trigger) {
+      return;
+    }
+    _dispatch(trigger, trigger.dataset.change, event);
+  });
+
+  // 委托 Enter 键：输入框用 data-enter 指定动作键，仅在按下回车时触发。
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter") {
+      return;
+    }
+    const trigger = event.target.closest("[data-enter]");
+    if (!trigger) {
       return;
     }
     event.preventDefault();
-    Promise.resolve()
-      .then(() => handler(trigger, event))
-      .catch(() => {});
+    _dispatch(trigger, trigger.dataset.enter, event);
   });
 
   window.AdminShell = {

--- a/src/web/assets/admin/pages/activity_content.html
+++ b/src/web/assets/admin/pages/activity_content.html
@@ -2,7 +2,7 @@
         <article class="surface-card">
           <div class="action-row">
             <span id="activityState" class="micro-status is-warning">等待同步</span>
-            <button class="btn btn-primary" type="button" onclick="loadActivity().catch(() => {})">刷新统计</button>
+            <button class="btn btn-primary" type="button" data-action="refresh-activity">刷新统计</button>
           </div>
         </article>
 

--- a/src/web/assets/admin/pages/activity_script.js
+++ b/src/web/assets/admin/pages/activity_script.js
@@ -206,5 +206,8 @@
       await check();
     }
 
+    AdminShell.registerActions({
+      "refresh-activity": () => loadActivity(),
+    });
     AdminShell.init({ page: "activity", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/areas_content.html
+++ b/src/web/assets/admin/pages/areas_content.html
@@ -2,7 +2,7 @@
         <article class="surface-card">
           <div class="action-row" style="flex-wrap:wrap">
             <span id="areaState" class="micro-status is-warning">等待同步</span>
-            <select id="areaPicker" class="m-area-select" onchange="onAreaChange()">
+            <select id="areaPicker" class="m-area-select" data-change="area-change">
               <option value="">加载中...</option>
             </select>
             <button class="btn btn-ghost" type="button" data-action="refresh-areas">刷新</button>
@@ -22,13 +22,13 @@
             <div class="field field--wide"><label for="ac_name">域名称</label><input id="ac_name" type="text" placeholder="仅日志显示" /></div>
             <div class="field field--wide">
               <label for="ac_default_channel_select">默认频道</label>
-              <select id="ac_default_channel_select" onchange="onDefaultChannelSelectChange()">
+              <select id="ac_default_channel_select" data-change="default-channel-change">
                 <option value="">先选择域后加载频道</option>
               </select>
             </div>
             <div class="field field--wide">
               <label for="ac_auto_role_select">自动分配身份组</label>
-              <select id="ac_auto_role_select" onchange="onAutoRoleSelectChange()">
+              <select id="ac_auto_role_select" data-change="auto-role-change">
                 <option value="">先选择域后加载身份组</option>
               </select>
             </div>
@@ -153,10 +153,10 @@
                 </select>
               </div>
               <div class="field field--check">
-                <label><input id="editChSecret" type="checkbox" onchange="toggleSecretPanel()" /> 私密频道</label>
+                <label><input id="editChSecret" type="checkbox" data-change="toggle-secret-panel" /> 私密频道</label>
               </div>
               <div class="field field--check">
-                <label><input id="editChHasPassword" type="checkbox" onchange="toggleEditPwd()" /> 启用密码</label>
+                <label><input id="editChHasPassword" type="checkbox" data-change="toggle-edit-pwd" /> 启用密码</label>
               </div>
               <div class="field field--wide" id="editChPwdWrap" style="display:none">
                 <label for="editChPassword">频道密码</label>

--- a/src/web/assets/admin/pages/areas_content.html
+++ b/src/web/assets/admin/pages/areas_content.html
@@ -5,7 +5,7 @@
             <select id="areaPicker" class="m-area-select" onchange="onAreaChange()">
               <option value="">加载中...</option>
             </select>
-            <button class="btn btn-ghost" type="button" onclick="loadAreaManager()">刷新</button>
+            <button class="btn btn-ghost" type="button" data-action="refresh-areas">刷新</button>
           </div>
         </article>
 
@@ -14,8 +14,8 @@
           <div class="section-head">
             <h3 class="section-title">域配置</h3>
             <div class="action-row" style="gap:6px">
-              <button class="btn btn-primary btn-sm" type="button" onclick="saveAreaConfig()">保存配置</button>
-              <button class="btn btn-danger btn-sm" type="button" onclick="deleteAreaConfig()">删除配置</button>
+              <button class="btn btn-primary btn-sm" type="button" data-action="save-area-config">保存配置</button>
+              <button class="btn btn-danger btn-sm" type="button" data-action="delete-area-config">删除配置</button>
             </div>
           </div>
           <div class="field-grid" style="padding:16px 20px">
@@ -59,7 +59,7 @@
             <h3 class="section-title">频道列表</h3>
             <div style="display:flex;align-items:center;gap:8px">
               <span class="a-id-label">域 ID: <code id="areaIdDisplay" class="a-id-code">-</code></span>
-              <button class="btn btn-ghost btn-sm" type="button" onclick="showCreateChannel()">创建频道</button>
+              <button class="btn btn-ghost btn-sm" type="button" data-action="show-create-channel">创建频道</button>
             </div>
           </div>
           <div class="table-shell">
@@ -83,7 +83,7 @@
         <article class="table-card" id="voiceCard">
           <div class="section-head">
             <h3 class="section-title">语音频道监控</h3>
-            <button class="btn btn-ghost btn-sm" type="button" onclick="loadVoiceChannels()">刷新</button>
+            <button class="btn btn-ghost btn-sm" type="button" data-action="load-voice-channels">刷新</button>
           </div>
           <div id="voiceList" class="a-voice-list">
             <p class="empty-state">暂无语音频道数据</p>
@@ -91,11 +91,11 @@
         </article>
 
         <!-- 创建频道对话框 -->
-        <div id="chModalOverlay" class="m-modal-overlay" onclick="closeChModal()"></div>
+        <div id="chModalOverlay" class="m-modal-overlay" data-action="close-ch-modal"></div>
         <div id="chModalDialog" class="m-modal">
           <header class="m-modal__head">
             <h3 class="m-modal__title">创建频道</h3>
-            <button class="m-modal__close" onclick="closeChModal()" aria-label="关闭">&times;</button>
+            <button class="m-modal__close" type="button" data-action="close-ch-modal" aria-label="关闭">&times;</button>
           </header>
           <div class="m-modal__body">
             <div class="field"><label for="newChName">频道名称</label><input id="newChName" type="text" placeholder="输入频道名称" /></div>
@@ -109,17 +109,17 @@
             <div id="createChMsg" class="msg"></div>
           </div>
           <footer class="m-modal__foot">
-            <button class="btn btn-ghost" type="button" onclick="closeChModal()">取消</button>
-            <button class="btn btn-primary" type="button" onclick="doCreateChannel()">创建</button>
+            <button class="btn btn-ghost" type="button" data-action="close-ch-modal">取消</button>
+            <button class="btn btn-primary" type="button" data-action="do-create-channel">创建</button>
           </footer>
         </div>
 
         <!-- 编辑频道对话框 -->
-        <div id="editChOverlay" class="m-modal-overlay" onclick="closeEditChannel()"></div>
+        <div id="editChOverlay" class="m-modal-overlay" data-action="close-edit-channel"></div>
         <div id="editChDialog" class="m-modal" style="width:min(520px,92vw)">
           <header class="m-modal__head">
             <h3 id="editChTitle" class="m-modal__title">编辑频道</h3>
-            <button class="m-modal__close" onclick="closeEditChannel()" aria-label="关闭">&times;</button>
+            <button class="m-modal__close" type="button" data-action="close-edit-channel" aria-label="关闭">&times;</button>
           </header>
           <div class="m-modal__body">
             <input id="editChId" type="hidden" />
@@ -176,8 +176,8 @@
             <div id="editChMsg" class="msg" style="margin-top:12px"></div>
           </div>
           <footer class="m-modal__foot">
-            <button class="btn btn-ghost" type="button" onclick="closeEditChannel()">取消</button>
-            <button class="btn btn-primary" type="button" onclick="doSaveChannelSettings()">保存</button>
+            <button class="btn btn-ghost" type="button" data-action="close-edit-channel">取消</button>
+            <button class="btn btn-primary" type="button" data-action="do-save-channel-settings">保存</button>
           </footer>
         </div>
       </section>

--- a/src/web/assets/admin/pages/areas_script.js
+++ b/src/web/assets/admin/pages/areas_script.js
@@ -446,7 +446,7 @@
       el.innerHTML = _onlineMembers.map(function(m) {
         var checked = _selectedUids.has(m.uid) ? " checked" : "";
         return '<label class="a-am-item">'
-          + '<input type="checkbox" onchange="toggleAccessMember(\'' + esc(m.uid) + '\', this.checked)"' + checked + ' />'
+          + '<input type="checkbox" data-change="access-member" data-uid="' + esc(m.uid) + '"' + checked + ' />'
           + '<span class="a-am-dot"></span>'
           + '<span class="a-am-name">' + esc(m.name) + '</span>'
           + '</label>';
@@ -561,6 +561,12 @@
       "do-save-channel-settings": () => doSaveChannelSettings(),
       "show-edit-channel": (el) => showEditChannel(el.dataset.chId, el.dataset.chType),
       "do-delete-channel": (el) => doDeleteChannel(el.dataset.chId, el.dataset.chName),
+      "area-change": () => onAreaChange(),
+      "default-channel-change": () => onDefaultChannelSelectChange(),
+      "auto-role-change": () => onAutoRoleSelectChange(),
+      "toggle-secret-panel": () => toggleSecretPanel(),
+      "toggle-edit-pwd": () => toggleEditPwd(),
+      "access-member": (el) => toggleAccessMember(el.dataset.uid, el.checked),
     });
     AdminShell.init({ page: "areas", passwordHandler: login });
     AdminShell.upgradeSelect("ac_default_channel_select");

--- a/src/web/assets/admin/pages/areas_script.js
+++ b/src/web/assets/admin/pages/areas_script.js
@@ -549,6 +549,9 @@
       }
     }
 
+    AdminShell.registerActions({
+      "refresh-areas": () => loadAreaManager(),
+    });
     AdminShell.init({ page: "areas", passwordHandler: login });
     AdminShell.upgradeSelect("ac_default_channel_select");
     AdminShell.upgradeSelect("ac_auto_role_select");

--- a/src/web/assets/admin/pages/areas_script.js
+++ b/src/web/assets/admin/pages/areas_script.js
@@ -329,8 +329,8 @@
             <td>${badges}</td>
             <td>
               <div class="a-ch-actions">
-                <button class="btn btn-ghost" onclick="showEditChannel('${esc(ch.id)}','${esc(ch.type)}')">编辑</button>
-                <button class="btn btn-danger" onclick="doDeleteChannel('${esc(ch.id)}','${esc(ch.name)}')">删除</button>
+                <button class="btn btn-ghost" type="button" data-action="show-edit-channel" data-ch-id="${esc(ch.id)}" data-ch-type="${esc(ch.type)}">编辑</button>
+                <button class="btn btn-danger" type="button" data-action="do-delete-channel" data-ch-id="${esc(ch.id)}" data-ch-name="${esc(ch.name)}">删除</button>
               </div>
             </td>
           </tr>`;
@@ -551,6 +551,16 @@
 
     AdminShell.registerActions({
       "refresh-areas": () => loadAreaManager(),
+      "save-area-config": () => saveAreaConfig(),
+      "delete-area-config": () => deleteAreaConfig(),
+      "show-create-channel": () => showCreateChannel(),
+      "load-voice-channels": () => loadVoiceChannels(),
+      "close-ch-modal": () => closeChModal(),
+      "do-create-channel": () => doCreateChannel(),
+      "close-edit-channel": () => closeEditChannel(),
+      "do-save-channel-settings": () => doSaveChannelSettings(),
+      "show-edit-channel": (el) => showEditChannel(el.dataset.chId, el.dataset.chType),
+      "do-delete-channel": (el) => doDeleteChannel(el.dataset.chId, el.dataset.chName),
     });
     AdminShell.init({ page: "areas", passwordHandler: login });
     AdminShell.upgradeSelect("ac_default_channel_select");

--- a/src/web/assets/admin/pages/config_content.html
+++ b/src/web/assets/admin/pages/config_content.html
@@ -49,7 +49,7 @@
                   <label for="cfg_admin_password">后台新密码</label>
                   <div class="secret-input">
                     <input id="cfg_admin_password" type="password" placeholder="留空表示不修改" />
-                    <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_admin_password', this)">显示</button>
+                    <button class="btn btn-sm btn-ghost" type="button" data-action="toggle-secret" data-secret="cfg_admin_password">显示</button>
                   </div>
                 </div>
                 <div class="field field--check">
@@ -75,7 +75,7 @@
                   <label for="cfg_redis_password">Redis 密码</label>
                   <div class="secret-input">
                     <input id="cfg_redis_password" type="password" placeholder="留空表示不修改" />
-                    <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_redis_password', this)">显示</button>
+                    <button class="btn btn-sm btn-ghost" type="button" data-action="toggle-secret" data-secret="cfg_redis_password">显示</button>
                   </div>
                 </div>
               </div>
@@ -101,7 +101,7 @@
                 <div class="field field--wide">
                   <label>关键词回复</label>
                   <div id="cfg_kw_list" class="kw-editor"></div>
-                  <button type="button" class="kw-add-btn" onclick="window._kwAdd()">+ 添加关键词</button>
+                  <button type="button" class="kw-add-btn" data-action="kw-add">+ 添加关键词</button>
                 </div>
                 <div class="field field--check"><label><input id="cfg_profanity_enabled" type="checkbox" /> 启用脏话检测</label></div>
                 <div class="field field--check"><label><input id="cfg_profanity_recall" type="checkbox" /> 自动撤回脏话消息</label></div>
@@ -152,7 +152,7 @@
                   <div class="secret-input">
                     <input id="cfg_oopz_login_phone" type="text" inputmode="tel" autocomplete="username" placeholder="手机号；留空则用配置" />
                     <input id="cfg_oopz_login_password" type="password" autocomplete="current-password" placeholder="密码；留空则用配置" />
-                    <button id="cfg_oopz_login_btn" class="btn btn-sm btn-primary" type="button" onclick="loginOopzAccount()">登录并获取</button>
+                    <button id="cfg_oopz_login_btn" class="btn btn-sm btn-primary" type="button" data-action="oopz-login">登录并获取</button>
                   </div>
                   <div id="cfg_oopz_login_status" class="msg">等待登录</div>
                 </div>
@@ -167,8 +167,8 @@
                   <label>网易云扫码登录</label>
                   <div class="netease-login">
                     <div class="action-row">
-                      <button id="cfg_netease_qr_refresh" class="btn btn-sm btn-primary" type="button" onclick="refreshNeteaseQr()">刷新二维码</button>
-                      <button id="cfg_netease_qr_save_runtime" class="btn btn-sm btn-ghost" type="button" onclick="saveNeteaseQrCookie(true)" disabled>保存并立即生效</button>
+                      <button id="cfg_netease_qr_refresh" class="btn btn-sm btn-primary" type="button" data-action="netease-qr-refresh">刷新二维码</button>
+                      <button id="cfg_netease_qr_save_runtime" class="btn btn-sm btn-ghost" type="button" data-action="netease-qr-save" disabled>保存并立即生效</button>
                     </div>
                     <div class="netease-login__body">
                       <div id="cfg_netease_qr_box" class="netease-qr-box">
@@ -191,7 +191,7 @@
                   <div class="netease-account-panel" data-netease-account-status>当前网易云账号：未检测</div>
                   <div class="secret-input">
                     <input id="cfg_netease_cookie" type="password" placeholder="留空表示不修改" />
-                    <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_netease_cookie', this)">显示</button>
+                    <button class="btn btn-sm btn-ghost" type="button" data-action="toggle-secret" data-secret="cfg_netease_cookie">显示</button>
                   </div>
                 </div>
               </div>
@@ -231,7 +231,7 @@
                   <label for="cfg_qq_music_cookie">Cookie</label>
                   <div class="secret-input">
                     <input id="cfg_qq_music_cookie" type="password" placeholder="留空表示不修改" />
-                    <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_qq_music_cookie', this)">显示</button>
+                    <button class="btn btn-sm btn-ghost" type="button" data-action="toggle-secret" data-secret="cfg_qq_music_cookie">显示</button>
                   </div>
                 </div>
               </div>
@@ -248,8 +248,8 @@
                   <label>B 站扫码登录</label>
                   <div class="qr-login">
                     <div class="action-row">
-                      <button id="cfg_bilibili_qr_refresh" class="btn btn-sm btn-primary" type="button" onclick="refreshBilibiliQr()">刷新二维码</button>
-                      <button id="cfg_bilibili_qr_save_runtime" class="btn btn-sm btn-ghost" type="button" onclick="saveBilibiliQrCookie(true)" disabled>保存并立即生效</button>
+                      <button id="cfg_bilibili_qr_refresh" class="btn btn-sm btn-primary" type="button" data-action="bilibili-qr-refresh">刷新二维码</button>
+                      <button id="cfg_bilibili_qr_save_runtime" class="btn btn-sm btn-ghost" type="button" data-action="bilibili-qr-save" disabled>保存并立即生效</button>
                     </div>
                     <div class="qr-login__body">
                       <div id="cfg_bilibili_qr_box" class="qr-box">
@@ -268,7 +268,7 @@
                   <div id="cfg_bilibili_account_status" class="account-panel" data-bilibili-account-status>当前B站账号：未检测</div>
                   <div class="secret-input">
                     <input id="cfg_bilibili_cookie" type="password" placeholder="留空表示不修改" />
-                    <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_bilibili_cookie', this)">显示</button>
+                    <button class="btn btn-sm btn-ghost" type="button" data-action="toggle-secret" data-secret="cfg_bilibili_cookie">显示</button>
                   </div>
                 </div>
               </div>
@@ -295,7 +295,7 @@
                   <label for="cfg_doubao_api_key">API Key</label>
                   <div class="secret-input">
                     <input id="cfg_doubao_api_key" type="password" placeholder="留空表示不修改" />
-                    <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_doubao_api_key', this)">显示</button>
+                    <button class="btn btn-sm btn-ghost" type="button" data-action="toggle-secret" data-secret="cfg_doubao_api_key">显示</button>
                   </div>
                 </div>
               </div>
@@ -316,7 +316,7 @@
                   <label for="cfg_doubao_img_api_key">API Key</label>
                   <div class="secret-input">
                     <input id="cfg_doubao_img_api_key" type="password" placeholder="留空表示不修改" />
-                    <button class="btn btn-sm btn-ghost" type="button" onclick="toggleSecret('cfg_doubao_img_api_key', this)">显示</button>
+                    <button class="btn btn-sm btn-ghost" type="button" data-action="toggle-secret" data-secret="cfg_doubao_img_api_key">显示</button>
                   </div>
                 </div>
               </div>

--- a/src/web/assets/admin/pages/config_content.html
+++ b/src/web/assets/admin/pages/config_content.html
@@ -1,4 +1,4 @@
-      <section id="panel" class="hidden config-layout">
+      <section id="panel" class="hidden config-layout config-layout--single">
         <div class="surface-card">
           <div class="cfg-tabs" role="tablist">
             <button class="cfg-tab is-active" data-tab="basic" type="button">基础设置</button>
@@ -7,6 +7,7 @@
             <button class="cfg-tab" data-tab="ai" type="button">AI 服务</button>
             <button class="cfg-tab" data-tab="schedule" type="button">定时与通知</button>
           </div>
+          <div id="msg" class="msg config-message" aria-live="polite"></div>
 
           <!-- Tab: 基础设置 -->
           <div class="cfg-panel is-active" data-panel="basic">
@@ -351,17 +352,4 @@
             </section>
           </div>
         </div>
-
-        <aside class="sticky-rail">
-          <div class="rail-block">
-            <div id="railState" class="micro-status is-warning">等待操作</div>
-            <h3 class="rail-block__title">保存操作</h3>
-            <div class="action-row">
-              <button class="btn btn-primary" type="button" onclick="saveConfig(true)">保存到 config.py</button>
-              <button class="btn btn-ghost" type="button" onclick="loadConfig()">放弃页面修改</button>
-              <button class="btn btn-ghost" type="button" onclick="resetOverrides()">按 config.py 恢复运行配置</button>
-            </div>
-            <div id="msg" class="msg"></div>
-          </div>
-        </aside>
       </section>

--- a/src/web/assets/admin/pages/config_script.js
+++ b/src/web/assets/admin/pages/config_script.js
@@ -9,13 +9,12 @@
       var row = document.createElement("div");
       row.className = "kw-row";
       row.innerHTML =
-        '<input class="kw-key" type="text" placeholder="关键词" value="' + _kwEsc(key) + '">' +
-        '<input class="kw-val" type="text" placeholder="回复内容" value="' + _kwEsc(val) + '">' +
+        '<input class="kw-key" type="text" placeholder="关键词" value="' + AdminShell.escapeHtml(key) + '">' +
+        '<input class="kw-val" type="text" placeholder="回复内容" value="' + AdminShell.escapeHtml(val) + '">' +
         '<button type="button" class="kw-del" title="删除">&times;</button>';
       row.querySelector(".kw-del").onclick = function() { row.remove(); };
       list.appendChild(row);
     }
-    function _kwEsc(s) { return String(s || "").replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/</g,"&lt;"); }
     window._kwAdd = function() {
       var list = AdminShell.byId("cfg_kw_list");
       if (!list) return;
@@ -68,7 +67,6 @@
     function setPageState(text, variant) {
       AdminShell.setStatus(text, variant, "topStatus");
       AdminShell.setStatus(text, variant, "mobileStatus");
-      AdminShell.setStatus(text, variant, "railState");
     }
 
     function renderMusicAreaHint(info) {
@@ -83,402 +81,316 @@
       hint.textContent = "当前音乐域：" + area + "；来源：" + sourceText + "；活跃域：" + activeArea + "；默认域：" + defaultArea;
     }
 
-    let neteaseQrTimer = null;
-    let neteaseQrKey = "";
-    let neteaseQrBaseUrl = "";
+    // 扫码登录通用控制器：网易云 / B 站共用同一套二维码刷新、轮询、
+    // 账号状态与 Cookie 回填逻辑，仅通过 config 注入各自的 DOM id、
+    // 接口端点和文案差异。
+    function createQrLoginController(config) {
+      let timer = null;
+      let key = "";
+      let baseUrl = "";
 
-    function setNeteaseQrStatus(text, isError) {
-      const element = AdminShell.byId("cfg_netease_qr_status");
-      if (!element) {
-        return;
-      }
-      element.textContent = text || "";
-      element.style.color = isError ? "var(--danger)" : "var(--ink-faint)";
-    }
-
-    function renderNeteaseAccount(profile, message, isError) {
-      const targets = Array.from(document.querySelectorAll("[data-netease-account-status]"));
-      if (!targets.length) return;
-      if (profile && profile.user_id) {
-        const nickname = profile.nickname || "未命名账号";
-        const text = "当前网易云账号：" + nickname + "（ID：" + profile.user_id + "）";
-        targets.forEach(function (element) {
-          element.textContent = text;
-          element.style.color = "var(--success)";
-        });
-        return;
-      }
-      const text = "当前网易云账号：" + (message || "未登录");
-      targets.forEach(function (element) {
-        element.textContent = text;
+      function setStatus(text, isError) {
+        const element = AdminShell.byId(config.ids.status);
+        if (!element) {
+          return;
+        }
+        element.textContent = text || "";
         element.style.color = isError ? "var(--danger)" : "var(--ink-faint)";
-      });
-    }
+      }
 
-    async function loadNeteaseAccountStatus(configured) {
-      if (!configured) {
-        renderNeteaseAccount(null, "未登录", false);
-        return;
-      }
-      renderNeteaseAccount(null, "检测中...", false);
-      try {
-        const data = await AdminShell.req("/admin/api/netease/account");
-        if (data.logged_in) {
-          renderNeteaseAccount(data.profile || null, "", false);
-        } else {
-          renderNeteaseAccount(null, data.message || "未登录或 Cookie 已过期", false);
-        }
-      } catch (error) {
-        renderNeteaseAccount(null, error.message || "账号状态检测失败", true);
-      }
-    }
-
-    function setNeteaseQrSaveEnabled(enabled) {
-      const runtimeButton = AdminShell.byId("cfg_netease_qr_save_runtime");
-      if (runtimeButton) {
-        runtimeButton.disabled = !enabled;
-      }
-    }
-
-    function stopNeteaseQrPolling() {
-      if (neteaseQrTimer) {
-        window.clearInterval(neteaseQrTimer);
-        neteaseQrTimer = null;
-      }
-    }
-
-    function resetNeteaseQrView(text) {
-      const image = AdminShell.byId("cfg_netease_qr_img");
-      const empty = AdminShell.byId("cfg_netease_qr_empty");
-      const link = AdminShell.byId("cfg_netease_qr_link");
-      if (image) {
-        image.hidden = true;
-        image.removeAttribute("src");
-      }
-      if (empty) {
-        empty.hidden = false;
-        empty.textContent = text || "等待刷新";
-      }
-      if (link) {
-        link.hidden = true;
-        link.href = "#";
-      }
-    }
-
-    function fillNeteaseCookie(cookie) {
-      setSecretValue("cfg_netease_cookie", cookie, true);
-      setNeteaseQrSaveEnabled(!!cookie);
-    }
-
-    async function checkNeteaseQr() {
-      if (!neteaseQrKey) {
-        stopNeteaseQrPolling();
-        return;
-      }
-      try {
-        const data = await AdminShell.req("/admin/api/netease/login/qr/check", {
-          method: "POST",
-          body: JSON.stringify({
-            base_url: neteaseQrBaseUrl || val("cfg_netease_base_url"),
-            key: neteaseQrKey,
-          }),
-        });
-        if (data.status === "waiting") {
-          setNeteaseQrStatus(data.message || "等待扫码", false);
-          return;
-        }
-        if (data.status === "scanned") {
-          setNeteaseQrStatus(data.message || "已扫码，请在手机上确认", false);
-          return;
-        }
-        if (data.status === "expired") {
-          stopNeteaseQrPolling();
-          neteaseQrKey = "";
-          setNeteaseQrStatus(data.message || "二维码已过期", true);
-          resetNeteaseQrView("已过期");
-          setPageState("网易云二维码过期", "warning");
-          return;
-        }
-        if (data.status === "success") {
-          stopNeteaseQrPolling();
-          neteaseQrKey = "";
-          fillNeteaseCookie(data.cookie || "");
-          renderNeteaseAccount(data.profile || null, data.profile_message || "已登录，账号信息待保存后刷新", false);
-          setNeteaseQrStatus("登录成功，Cookie 已填入", false);
-          AdminShell.showMessage("msg", "网易云 Cookie 已填入，可选择保存方式");
-          setPageState("网易云登录成功", "success");
-          return;
-        }
-        setNeteaseQrStatus(data.message || "等待网易云返回登录状态", false);
-      } catch (error) {
-        stopNeteaseQrPolling();
-        neteaseQrKey = "";
-        setNeteaseQrStatus(error.message || "登录状态检查失败", true);
-        setPageState("网易云登录检查失败", "error");
-      }
-    }
-
-    async function refreshNeteaseQr() {
-      const button = AdminShell.byId("cfg_netease_qr_refresh");
-      stopNeteaseQrPolling();
-      neteaseQrKey = "";
-      neteaseQrBaseUrl = "";
-      setNeteaseQrSaveEnabled(false);
-      resetNeteaseQrView("刷新中");
-      setNeteaseQrStatus("正在获取二维码...", false);
-      setPageState("网易云二维码刷新中", "warning");
-      if (button) {
-        button.disabled = true;
-        button.textContent = "刷新中...";
-      }
-      try {
-        const data = await AdminShell.req("/admin/api/netease/login/qr", {
-          method: "POST",
-          body: JSON.stringify({ base_url: val("cfg_netease_base_url") }),
-        });
-        neteaseQrKey = data.key || "";
-        neteaseQrBaseUrl = data.base_url || val("cfg_netease_base_url");
-        const image = AdminShell.byId("cfg_netease_qr_img");
-        const empty = AdminShell.byId("cfg_netease_qr_empty");
-        const link = AdminShell.byId("cfg_netease_qr_link");
-        if (image && data.qrimg) {
-          image.src = data.qrimg;
-          image.hidden = false;
-        }
-        if (empty) {
-          empty.hidden = !!data.qrimg;
-          empty.textContent = data.qrimg ? "" : "二维码链接已生成";
-        }
-        if (link && data.qrurl) {
-          link.href = data.qrurl;
-          link.hidden = false;
-        }
-        setNeteaseQrStatus(data.message || "等待扫码", false);
-        neteaseQrTimer = window.setInterval(checkNeteaseQr, 2500);
-        window.setTimeout(checkNeteaseQr, 900);
-      } catch (error) {
-        resetNeteaseQrView("刷新失败");
-        setNeteaseQrStatus(error.message || "二维码刷新失败", true);
-        setPageState("网易云二维码刷新失败", "error");
-      } finally {
-        if (button) {
-          button.disabled = false;
-          button.textContent = "刷新二维码";
-        }
-      }
-    }
-
-    async function saveNeteaseQrCookie(persist) {
-      if (!val("cfg_netease_cookie")) {
-        setNeteaseQrStatus("请先完成扫码登录", true);
-        return;
-      }
-      await saveConfig(true);
-    }
-
-    let bilibiliQrTimer = null;
-    let bilibiliQrKey = "";
-
-    function setBilibiliQrStatus(text, isError) {
-      const element = AdminShell.byId("cfg_bilibili_qr_status");
-      if (!element) {
-        return;
-      }
-      element.textContent = text || "";
-      element.style.color = isError ? "var(--danger)" : "var(--ink-faint)";
-    }
-
-    function renderBilibiliAccount(profile, message, isError) {
-      const targets = Array.from(document.querySelectorAll("[data-bilibili-account-status]"));
-      let text = "";
-      if (!targets.length) {
+      function accountText(profile, message) {
         if (profile && profile.user_id) {
           const nickname = profile.nickname || "未命名账号";
-          setBilibiliQrStatus("当前B站账号：" + nickname + "（ID：" + profile.user_id + "）", false);
-        } else if (message) {
-          setBilibiliQrStatus("当前B站账号：" + message, !!isError);
+          return config.accountLabel + nickname + "（ID：" + profile.user_id + "）";
         }
-        return;
+        return message || config.accountLabel + "已登录，账号信息待保存后刷新";
       }
-      if (profile && profile.user_id) {
-        const nickname = profile.nickname || "未命名账号";
-        text = "当前B站账号：" + nickname + "（ID：" + profile.user_id + "）";
+
+      function renderAccount(profile, message, isError) {
+        const targets = Array.from(document.querySelectorAll(config.accountSelector));
+        if (!targets.length) {
+          return;
+        }
+        let text;
+        let color;
+        if (profile && profile.user_id) {
+          text = config.accountLabel + (profile.nickname || "未命名账号") + "（ID：" + profile.user_id + "）";
+          color = "var(--success)";
+        } else {
+          text = config.accountLabel + (message || "未登录");
+          color = isError ? "var(--danger)" : "var(--ink-faint)";
+        }
         targets.forEach(function (element) {
           element.textContent = text;
-          element.style.color = "var(--success)";
+          element.style.color = color;
         });
-        return;
       }
-      text = "当前B站账号：" + (message || "未登录");
-      targets.forEach(function (element) {
-        element.textContent = text;
-        element.style.color = isError ? "var(--danger)" : "var(--ink-faint)";
-      });
-    }
 
-    function bilibiliAccountText(profile, fallback) {
-      if (profile && profile.user_id) {
-        const nickname = profile.nickname || "未命名账号";
-        return "当前B站账号：" + nickname + "（ID：" + profile.user_id + "）";
-      }
-      return fallback || "当前B站账号：已登录，账号信息待保存后刷新";
-    }
-
-    async function loadBilibiliAccountStatus(configured) {
-      if (!configured) {
-        renderBilibiliAccount(null, "未登录", false);
-        return;
-      }
-      renderBilibiliAccount(null, "检测中...", false);
-      try {
-        const data = await AdminShell.req("/admin/api/bilibili/account");
-        if (data.logged_in) {
-          renderBilibiliAccount(data.profile || null, "", false);
-        } else {
-          renderBilibiliAccount(null, data.message || "未登录或 Cookie 已过期", false);
-        }
-      } catch (error) {
-        renderBilibiliAccount(null, error.message || "账号状态检测失败", true);
-      }
-    }
-
-    function setBilibiliQrSaveEnabled(enabled) {
-      const runtimeButton = AdminShell.byId("cfg_bilibili_qr_save_runtime");
-      if (runtimeButton) {
-        runtimeButton.disabled = !enabled;
-      }
-    }
-
-    function stopBilibiliQrPolling() {
-      if (bilibiliQrTimer) {
-        window.clearInterval(bilibiliQrTimer);
-        bilibiliQrTimer = null;
-      }
-    }
-
-    function resetBilibiliQrView(text) {
-      const image = AdminShell.byId("cfg_bilibili_qr_img");
-      const empty = AdminShell.byId("cfg_bilibili_qr_empty");
-      const link = AdminShell.byId("cfg_bilibili_qr_link");
-      if (image) {
-        image.hidden = true;
-        image.removeAttribute("src");
-      }
-      if (empty) {
-        empty.hidden = false;
-        empty.textContent = text || "等待刷新";
-      }
-      if (link) {
-        link.hidden = true;
-        link.href = "#";
-      }
-    }
-
-    function fillBilibiliCookie(cookie) {
-      setSecretValue("cfg_bilibili_cookie", cookie, true);
-      setBilibiliQrSaveEnabled(!!cookie);
-    }
-
-    async function checkBilibiliQr() {
-      if (!bilibiliQrKey) {
-        stopBilibiliQrPolling();
-        return;
-      }
-      try {
-        const data = await AdminShell.req("/admin/api/bilibili/login/qr/check", {
-          method: "POST",
-          body: JSON.stringify({ key: bilibiliQrKey }),
-        });
-        if (data.status === "waiting") {
-          setBilibiliQrStatus(data.message || "等待扫码", false);
+      async function loadAccountStatus(configured) {
+        if (!configured) {
+          renderAccount(null, "未登录", false);
           return;
         }
-        if (data.status === "scanned") {
-          setBilibiliQrStatus(data.message || "已扫码，请在手机上确认", false);
-          return;
+        renderAccount(null, "检测中...", false);
+        try {
+          const data = await AdminShell.req(config.endpoints.account);
+          if (data.logged_in) {
+            renderAccount(data.profile || null, "", false);
+          } else {
+            renderAccount(null, data.message || "未登录或 Cookie 已过期", false);
+          }
+        } catch (error) {
+          renderAccount(null, error.message || "账号状态检测失败", true);
         }
-        if (data.status === "expired") {
-          stopBilibiliQrPolling();
-          bilibiliQrKey = "";
-          setBilibiliQrStatus(data.message || "二维码已过期", true);
-          resetBilibiliQrView("已过期");
-          setPageState("B 站二维码过期", "warning");
-          return;
-        }
-        if (data.status === "success") {
-          stopBilibiliQrPolling();
-          bilibiliQrKey = "";
-          fillBilibiliCookie(data.cookie || "");
-          const accountText = bilibiliAccountText(data.profile || null, data.profile_message || "");
-          renderBilibiliAccount(data.profile || null, data.profile_message || "已登录，账号信息待保存后刷新", false);
-          setBilibiliQrStatus("登录成功，Cookie 已填入", false);
-          AdminShell.showMessage("msg", "B 站 Cookie 已填入，可选择保存方式；" + accountText);
-          setPageState("B 站登录成功", "success");
-          return;
-        }
-        setBilibiliQrStatus(data.message || "等待 B 站返回登录状态", false);
-      } catch (error) {
-        stopBilibiliQrPolling();
-        bilibiliQrKey = "";
-        setBilibiliQrStatus(error.message || "登录状态检查失败", true);
-        setPageState("B 站登录检查失败", "error");
       }
-    }
 
-    async function refreshBilibiliQr() {
-      const button = AdminShell.byId("cfg_bilibili_qr_refresh");
-      stopBilibiliQrPolling();
-      bilibiliQrKey = "";
-      setBilibiliQrSaveEnabled(false);
-      resetBilibiliQrView("刷新中");
-      setBilibiliQrStatus("正在获取二维码...", false);
-      setPageState("B 站二维码刷新中", "warning");
-      if (button) {
-        button.disabled = true;
-        button.textContent = "刷新中...";
+      function setSaveEnabled(enabled) {
+        const runtimeButton = AdminShell.byId(config.ids.saveBtn);
+        if (runtimeButton) {
+          runtimeButton.disabled = !enabled;
+        }
       }
-      try {
-        const data = await AdminShell.req("/admin/api/bilibili/login/qr", {
-          method: "POST",
-          body: "{}",
-        });
-        bilibiliQrKey = data.key || "";
-        const image = AdminShell.byId("cfg_bilibili_qr_img");
-        const empty = AdminShell.byId("cfg_bilibili_qr_empty");
-        const link = AdminShell.byId("cfg_bilibili_qr_link");
-        if (image && data.qrimg) {
-          image.src = data.qrimg;
-          image.hidden = false;
+
+      function stopPolling() {
+        if (timer) {
+          window.clearInterval(timer);
+          timer = null;
+        }
+      }
+
+      function resetView(text) {
+        const image = AdminShell.byId(config.ids.img);
+        const empty = AdminShell.byId(config.ids.empty);
+        const link = AdminShell.byId(config.ids.link);
+        if (image) {
+          image.hidden = true;
+          image.removeAttribute("src");
         }
         if (empty) {
-          empty.hidden = !!data.qrimg;
-          empty.textContent = data.qrimg ? "" : "二维码链接已生成";
+          empty.hidden = false;
+          empty.textContent = text || "等待刷新";
         }
-        if (link && data.qrurl) {
-          link.href = data.qrurl;
-          link.hidden = false;
-        }
-        setBilibiliQrStatus(data.message || "等待扫码", false);
-        bilibiliQrTimer = window.setInterval(checkBilibiliQr, 2500);
-        window.setTimeout(checkBilibiliQr, 900);
-      } catch (error) {
-        resetBilibiliQrView("刷新失败");
-        setBilibiliQrStatus(error.message || "二维码刷新失败", true);
-        setPageState("B 站二维码刷新失败", "error");
-      } finally {
-        if (button) {
-          button.disabled = false;
-          button.textContent = "刷新二维码";
+        if (link) {
+          link.hidden = true;
+          link.href = "#";
         }
       }
+
+      function fillCookie(cookie) {
+        setSecretValue(config.ids.cookie, cookie, true);
+        setSaveEnabled(!!cookie);
+      }
+
+      async function check() {
+        if (!key) {
+          stopPolling();
+          return;
+        }
+        try {
+          const data = await AdminShell.req(config.endpoints.check, {
+            method: "POST",
+            body: config.buildCheckBody({ key: key, baseUrl: baseUrl }),
+          });
+          if (data.status === "waiting") {
+            setStatus(data.message || "等待扫码", false);
+            return;
+          }
+          if (data.status === "scanned") {
+            setStatus(data.message || "已扫码，请在手机上确认", false);
+            return;
+          }
+          if (data.status === "expired") {
+            stopPolling();
+            key = "";
+            setStatus(data.message || "二维码已过期", true);
+            resetView("已过期");
+            setPageState(config.platform + "二维码过期", "warning");
+            return;
+          }
+          if (data.status === "success") {
+            stopPolling();
+            key = "";
+            fillCookie(data.cookie || "");
+            const profileMessage = data.profile_message || "";
+            renderAccount(data.profile || null, profileMessage || "已登录，账号信息待保存后刷新", false);
+            setStatus("登录成功，Cookie 已填入", false);
+            AdminShell.showMessage(
+              "msg",
+              config.buildSuccessMessage(
+                data.profile || null,
+                profileMessage,
+                accountText(data.profile || null, profileMessage)
+              )
+            );
+            setPageState(config.platform + "登录成功", "success");
+            return;
+          }
+          setStatus(data.message || config.waitingDefault, false);
+        } catch (error) {
+          stopPolling();
+          key = "";
+          setStatus(error.message || "登录状态检查失败", true);
+          setPageState(config.platform + "登录检查失败", "error");
+        }
+      }
+
+      async function refresh() {
+        const button = AdminShell.byId(config.ids.refreshBtn);
+        stopPolling();
+        key = "";
+        baseUrl = "";
+        setSaveEnabled(false);
+        resetView("刷新中");
+        setStatus("正在获取二维码...", false);
+        setPageState(config.platform + "二维码刷新中", "warning");
+        if (button) {
+          button.disabled = true;
+          button.textContent = "刷新中...";
+        }
+        try {
+          const data = await AdminShell.req(config.endpoints.refresh, {
+            method: "POST",
+            body: config.buildRefreshBody(),
+          });
+          key = data.key || "";
+          baseUrl = config.resolveBaseUrl ? config.resolveBaseUrl(data) : "";
+          const image = AdminShell.byId(config.ids.img);
+          const empty = AdminShell.byId(config.ids.empty);
+          const link = AdminShell.byId(config.ids.link);
+          if (image && data.qrimg) {
+            image.src = data.qrimg;
+            image.hidden = false;
+          }
+          if (empty) {
+            empty.hidden = !!data.qrimg;
+            empty.textContent = data.qrimg ? "" : "二维码链接已生成";
+          }
+          if (link && data.qrurl) {
+            link.href = data.qrurl;
+            link.hidden = false;
+          }
+          setStatus(data.message || "等待扫码", false);
+          timer = window.setInterval(check, 2500);
+          window.setTimeout(check, 900);
+        } catch (error) {
+          resetView("刷新失败");
+          setStatus(error.message || "二维码刷新失败", true);
+          setPageState(config.platform + "二维码刷新失败", "error");
+        } finally {
+          if (button) {
+            button.disabled = false;
+            button.textContent = "刷新二维码";
+          }
+        }
+      }
+
+      async function save() {
+        if (!val(config.ids.cookie)) {
+          setStatus("请先完成扫码登录", true);
+          return;
+        }
+        await saveConfig(true);
+      }
+
+      return {
+        renderAccount: renderAccount,
+        loadAccountStatus: loadAccountStatus,
+        setSaveEnabled: setSaveEnabled,
+        check: check,
+        refresh: refresh,
+        save: save,
+      };
     }
 
-    async function saveBilibiliQrCookie(persist) {
-      if (!val("cfg_bilibili_cookie")) {
-        setBilibiliQrStatus("请先完成扫码登录", true);
-        return;
-      }
-      await saveConfig(true);
+    const neteaseQr = createQrLoginController({
+      platform: "网易云",
+      accountLabel: "当前网易云账号：",
+      accountSelector: "[data-netease-account-status]",
+      waitingDefault: "等待网易云返回登录状态",
+      ids: {
+        status: "cfg_netease_qr_status",
+        img: "cfg_netease_qr_img",
+        empty: "cfg_netease_qr_empty",
+        link: "cfg_netease_qr_link",
+        refreshBtn: "cfg_netease_qr_refresh",
+        saveBtn: "cfg_netease_qr_save_runtime",
+        cookie: "cfg_netease_cookie",
+      },
+      endpoints: {
+        refresh: "/admin/api/netease/login/qr",
+        check: "/admin/api/netease/login/qr/check",
+        account: "/admin/api/netease/account",
+      },
+      buildRefreshBody: function () {
+        return JSON.stringify({ base_url: val("cfg_netease_base_url") });
+      },
+      resolveBaseUrl: function (data) {
+        return data.base_url || val("cfg_netease_base_url");
+      },
+      buildCheckBody: function (state) {
+        return JSON.stringify({
+          base_url: state.baseUrl || val("cfg_netease_base_url"),
+          key: state.key,
+        });
+      },
+      buildSuccessMessage: function () {
+        return "网易云 Cookie 已填入，可选择保存方式";
+      },
+    });
+
+    const bilibiliQr = createQrLoginController({
+      platform: "B 站",
+      accountLabel: "当前B站账号：",
+      accountSelector: "[data-bilibili-account-status]",
+      waitingDefault: "等待 B 站返回登录状态",
+      ids: {
+        status: "cfg_bilibili_qr_status",
+        img: "cfg_bilibili_qr_img",
+        empty: "cfg_bilibili_qr_empty",
+        link: "cfg_bilibili_qr_link",
+        refreshBtn: "cfg_bilibili_qr_refresh",
+        saveBtn: "cfg_bilibili_qr_save_runtime",
+        cookie: "cfg_bilibili_cookie",
+      },
+      endpoints: {
+        refresh: "/admin/api/bilibili/login/qr",
+        check: "/admin/api/bilibili/login/qr/check",
+        account: "/admin/api/bilibili/account",
+      },
+      buildRefreshBody: function () {
+        return "{}";
+      },
+      buildCheckBody: function (state) {
+        return JSON.stringify({ key: state.key });
+      },
+      buildSuccessMessage: function (profile, profileMessage, accountText) {
+        return "B 站 Cookie 已填入，可选择保存方式；" + accountText;
+      },
+    });
+
+    // 以下全局包装函数供 config_content.html 内联 onclick 调用。
+    function loadNeteaseAccountStatus(configured) {
+      return neteaseQr.loadAccountStatus(configured);
+    }
+
+    function refreshNeteaseQr() {
+      return neteaseQr.refresh();
+    }
+
+    function saveNeteaseQrCookie(persist) {
+      return neteaseQr.save(persist);
+    }
+
+    function loadBilibiliAccountStatus(configured) {
+      return bilibiliQr.loadAccountStatus(configured);
+    }
+
+    function refreshBilibiliQr() {
+      return bilibiliQr.refresh();
+    }
+
+    function saveBilibiliQrCookie(persist) {
+      return bilibiliQr.save(persist);
     }
 
     function setSecretState(id, configured) {
@@ -620,98 +532,160 @@
       }
     }
 
+    // 配置字段声明表：loadConfig 与 build 共用同一份定义，避免两侧手写映射漂移。
+    // 普通字段在此声明；密钥、关键词回复、撤回排除命令等特殊字段单独处理。
+    function _cfgGet(obj, path) {
+      return path.split(".").reduce(function (acc, key) {
+        return acc == null ? undefined : acc[key];
+      }, obj);
+    }
+
+    function _cfgSet(obj, path, value) {
+      const keys = path.split(".");
+      let cur = obj;
+      for (let i = 0; i < keys.length - 1; i++) {
+        if (typeof cur[keys[i]] !== "object" || cur[keys[i]] === null) {
+          cur[keys[i]] = {};
+        }
+        cur = cur[keys[i]];
+      }
+      cur[keys[keys.length - 1]] = value;
+    }
+
+    // type: text | int | float | bool
+    // loadDef: 加载时的默认值；loadNullish 为 true 时用 ?? 取默认（保留 0），否则用 ||。
+    // buildDef: 保存时对空值套用的回退默认（仅个别字段需要）。
+    const CONFIG_FIELDS = [
+      { id: "cfg_web_url", path: "web_player.url", type: "text", loadDef: "" },
+      { id: "cfg_web_host", path: "web_player.host", type: "text", loadDef: "0.0.0.0", buildDef: "0.0.0.0" },
+      { id: "cfg_web_port", path: "web_player.port", type: "int", loadDef: 8080, buildDef: 8080 },
+      { id: "cfg_web_token_ttl", path: "web_player.token_ttl_seconds", type: "int", loadDef: 0 },
+      { id: "cfg_web_cookie_age", path: "web_player.cookie_max_age_seconds", type: "int", loadDef: 0 },
+      { id: "cfg_link_idle", path: "web_player.link_idle_release_seconds", type: "int", loadDef: 0 },
+      { id: "cfg_cookie_secure", path: "web_player.cookie_secure", type: "bool" },
+      { id: "cfg_admin_session_ttl", path: "web_player.admin_session_ttl_seconds", type: "int", loadDef: 0 },
+      { id: "cfg_admin_cookie_secure", path: "web_player.admin_cookie_secure", type: "bool" },
+
+      { id: "cfg_auto_recall_enabled", path: "auto_recall.enabled", type: "bool" },
+      { id: "cfg_auto_recall_delay", path: "auto_recall.delay", type: "int", loadDef: 30 },
+
+      { id: "cfg_area_notify_enabled", path: "area_join_notify.enabled", type: "bool" },
+      { id: "cfg_area_poll", path: "area_join_notify.poll_interval_seconds", type: "int", loadDef: 2 },
+      { id: "cfg_area_auto_role_id", path: "area_join_notify.auto_assign_role_id", type: "text", loadDef: "" },
+      { id: "cfg_area_auto_role_name", path: "area_join_notify.auto_assign_role_name", type: "text", loadDef: "" },
+      { id: "cfg_notify_join_tpl", path: "area_join_notify.message_template", type: "text", loadDef: "" },
+      { id: "cfg_notify_leave_tpl", path: "area_join_notify.message_template_leave", type: "text", loadDef: "" },
+
+      { id: "cfg_chat_enabled", path: "chat.enabled", type: "bool" },
+
+      { id: "cfg_profanity_enabled", path: "profanity.enabled", type: "bool" },
+      { id: "cfg_profanity_recall", path: "profanity.recall_message", type: "bool" },
+      { id: "cfg_mute_duration", path: "profanity.mute_duration", type: "int", loadDef: 5 },
+      { id: "cfg_warn_before_mute", path: "profanity.warn_before_mute", type: "bool" },
+      { id: "cfg_skip_admins", path: "profanity.skip_admins", type: "bool" },
+      { id: "cfg_context_detection", path: "profanity.context_detection", type: "bool" },
+      { id: "cfg_context_window", path: "profanity.context_window", type: "int", loadDef: 30 },
+      { id: "cfg_context_max_messages", path: "profanity.context_max_messages", type: "int", loadDef: 10 },
+      { id: "cfg_ai_detection", path: "profanity.ai_detection", type: "bool" },
+      { id: "cfg_ai_min_length", path: "profanity.ai_min_length", type: "int", loadDef: 2 },
+
+      { id: "cfg_oopz_default_area", path: "oopz.default_area", type: "text", loadDef: "" },
+      { id: "cfg_oopz_default_channel", path: "oopz.default_channel", type: "text", loadDef: "" },
+      { id: "cfg_oopz_proxy", path: "oopz.proxy", type: "text", loadDef: "" },
+      { id: "cfg_oopz_login_phone", path: "oopz.login_phone", type: "text", loadDef: "" },
+      { id: "cfg_agora_app_id", path: "oopz.agora_app_id", type: "text", loadDef: "" },
+      { id: "cfg_agora_timeout", path: "oopz.agora_init_timeout", type: "int", loadDef: 1800, buildDef: 1800 },
+
+      { id: "cfg_netease_base_url", path: "netease.base_url", type: "text", loadDef: "" },
+      { id: "cfg_netease_timeout", path: "netease.audio_download_timeout", type: "int", loadDef: 120 },
+      { id: "cfg_netease_retries", path: "netease.audio_download_retries", type: "int", loadDef: 2 },
+      { id: "cfg_netease_quality", path: "netease.audio_quality", type: "text", loadDef: "standard", buildDef: "standard" },
+
+      { id: "cfg_redis_host", path: "redis.host", type: "text", loadDef: "" },
+      { id: "cfg_redis_port", path: "redis.port", type: "int", loadDef: 6379 },
+      { id: "cfg_redis_db", path: "redis.db", type: "int", loadDef: 0 },
+      { id: "cfg_redis_decode", path: "redis.decode_responses", type: "bool" },
+
+      { id: "cfg_doubao_enabled", path: "doubao_chat.enabled", type: "bool" },
+      { id: "cfg_doubao_base_url", path: "doubao_chat.base_url", type: "text", loadDef: "" },
+      { id: "cfg_doubao_model", path: "doubao_chat.model", type: "text", loadDef: "" },
+      { id: "cfg_doubao_max_tokens", path: "doubao_chat.max_tokens", type: "int", loadDef: 256 },
+      { id: "cfg_doubao_temperature", path: "doubao_chat.temperature", type: "float", loadDef: 0.7, loadNullish: true },
+      { id: "cfg_doubao_system_prompt", path: "doubao_chat.system_prompt", type: "text", loadDef: "" },
+      { id: "cfg_doubao_context_rounds", path: "doubao_chat.context_max_rounds", type: "int", loadDef: 0, loadNullish: true },
+      { id: "cfg_doubao_context_ttl", path: "doubao_chat.context_ttl_seconds", type: "int", loadDef: 0, loadNullish: true },
+
+      { id: "cfg_doubao_img_enabled", path: "doubao_image.enabled", type: "bool" },
+      { id: "cfg_doubao_img_base_url", path: "doubao_image.base_url", type: "text", loadDef: "" },
+      { id: "cfg_doubao_img_model", path: "doubao_image.model", type: "text", loadDef: "" },
+      { id: "cfg_doubao_img_size", path: "doubao_image.size", type: "text", loadDef: "" },
+      { id: "cfg_doubao_img_watermark", path: "doubao_image.watermark", type: "bool" },
+
+      { id: "cfg_music_auto_play", path: "music.auto_play_enabled", type: "bool" },
+      { id: "cfg_music_volume", path: "music.default_volume", type: "int", loadDef: 50, loadNullish: true },
+
+      { id: "cfg_cooldown_enabled", path: "command_cooldown.enabled", type: "bool" },
+      { id: "cfg_cooldown_seconds", path: "command_cooldown.default_seconds", type: "int", loadDef: 3, loadNullish: true },
+      { id: "cfg_cooldown_exempt_admins", path: "command_cooldown.exempt_admins", type: "bool" },
+
+      { id: "cfg_qq_music_enabled", path: "qq_music.enabled", type: "bool" },
+      { id: "cfg_qq_music_base_url", path: "qq_music.base_url", type: "text", loadDef: "" },
+
+      { id: "cfg_bilibili_enabled", path: "bilibili_music.enabled", type: "bool" },
+
+      { id: "cfg_stats_enabled", path: "message_stats.enabled", type: "bool" },
+
+      { id: "cfg_scheduler_enabled", path: "scheduler.enabled", type: "bool" },
+      { id: "cfg_scheduler_interval", path: "scheduler.check_interval_seconds", type: "int", loadDef: 30, loadNullish: true },
+      { id: "cfg_reminder_enabled", path: "reminder.enabled", type: "bool" },
+      { id: "cfg_reminder_max_per_user", path: "reminder.max_per_user", type: "int", loadDef: 5, loadNullish: true },
+      { id: "cfg_reminder_max_delay", path: "reminder.max_delay_hours", type: "int", loadDef: 72, loadNullish: true },
+      { id: "cfg_reminder_interval", path: "reminder.check_interval_seconds", type: "int", loadDef: 15, loadNullish: true },
+    ];
+
+    function _loadField(config, field) {
+      if (field.type === "bool") {
+        setVal(field.id, _cfgGet(config, field.path));
+        return;
+      }
+      const raw = _cfgGet(config, field.path);
+      setVal(field.id, field.loadNullish ? (raw ?? field.loadDef) : (raw || field.loadDef));
+    }
+
+    function _buildField(updates, field) {
+      let value;
+      if (field.type === "bool") {
+        value = chk(field.id);
+      } else if (field.type === "int") {
+        value = getInt(field.id);
+        if (field.buildDef !== undefined) {
+          value = value || field.buildDef;
+        }
+      } else if (field.type === "float") {
+        value = getFloat(field.id);
+      } else {
+        value = val(field.id);
+        if (field.buildDef !== undefined) {
+          value = value || field.buildDef;
+        }
+      }
+      _cfgSet(updates, field.path, value);
+    }
+
     async function loadConfig() {
       const data = await AdminShell.req("/admin/api/config");
       const config = data.config || {};
       const runtime = data.runtime || {};
 
-      setVal("cfg_web_url", config.web_player?.url || "");
-      setVal("cfg_web_host", config.web_player?.host || "0.0.0.0");
-      setVal("cfg_web_port", config.web_player?.port || 8080);
-      setVal("cfg_web_token_ttl", config.web_player?.token_ttl_seconds || 0);
-      setVal("cfg_web_cookie_age", config.web_player?.cookie_max_age_seconds || 0);
-      setVal("cfg_link_idle", config.web_player?.link_idle_release_seconds || 0);
-      setVal("cfg_cookie_secure", config.web_player?.cookie_secure);
-      setVal("cfg_admin_session_ttl", config.web_player?.admin_session_ttl_seconds || 0);
-      setVal("cfg_admin_cookie_secure", config.web_player?.admin_cookie_secure);
+      CONFIG_FIELDS.forEach(function (field) {
+        _loadField(config, field);
+      });
 
-      setVal("cfg_auto_recall_enabled", config.auto_recall?.enabled);
-      setVal("cfg_auto_recall_delay", config.auto_recall?.delay || 30);
+      // 特殊字段：撤回排除命令以逗号串展示，关键词回复用键值编辑器渲染。
       setVal("cfg_auto_recall_exclude", (config.auto_recall?.exclude_commands || []).join(", "));
-      setVal("cfg_area_notify_enabled", config.area_join_notify?.enabled);
-      setVal("cfg_area_poll", config.area_join_notify?.poll_interval_seconds || 2);
-      setVal("cfg_area_auto_role_id", config.area_join_notify?.auto_assign_role_id || "");
-      setVal("cfg_area_auto_role_name", config.area_join_notify?.auto_assign_role_name || "");
-      setVal("cfg_chat_enabled", config.chat?.enabled);
       window._kwRender(config.chat?.keyword_replies || {});
-      setVal("cfg_profanity_enabled", config.profanity?.enabled);
-      setVal("cfg_profanity_recall", config.profanity?.recall_message);
-      setVal("cfg_mute_duration", config.profanity?.mute_duration || 5);
-      setVal("cfg_warn_before_mute", config.profanity?.warn_before_mute);
-      setVal("cfg_skip_admins", config.profanity?.skip_admins);
-      setVal("cfg_context_detection", config.profanity?.context_detection);
-      setVal("cfg_context_window", config.profanity?.context_window || 30);
-      setVal("cfg_context_max_messages", config.profanity?.context_max_messages || 10);
-      setVal("cfg_ai_detection", config.profanity?.ai_detection);
-      setVal("cfg_ai_min_length", config.profanity?.ai_min_length || 2);
 
-      setVal("cfg_oopz_default_area", config.oopz?.default_area || "");
-      setVal("cfg_oopz_default_channel", config.oopz?.default_channel || "");
-      setVal("cfg_oopz_proxy", config.oopz?.proxy || "");
-      setVal("cfg_oopz_login_phone", config.oopz?.login_phone || "");
-      setVal("cfg_agora_app_id", config.oopz?.agora_app_id || "");
-      setVal("cfg_agora_timeout", config.oopz?.agora_init_timeout || 1800);
-
-      setVal("cfg_netease_base_url", config.netease?.base_url || "");
-      setVal("cfg_netease_timeout", config.netease?.audio_download_timeout || 120);
-      setVal("cfg_netease_retries", config.netease?.audio_download_retries || 2);
-      setVal("cfg_netease_quality", config.netease?.audio_quality || "standard");
-
-      setVal("cfg_redis_host", config.redis?.host || "");
-      setVal("cfg_redis_port", config.redis?.port || 6379);
-      setVal("cfg_redis_db", config.redis?.db || 0);
-      setVal("cfg_redis_decode", config.redis?.decode_responses);
-
-      setVal("cfg_doubao_enabled", config.doubao_chat?.enabled);
-      setVal("cfg_doubao_base_url", config.doubao_chat?.base_url || "");
-      setVal("cfg_doubao_model", config.doubao_chat?.model || "");
-      setVal("cfg_doubao_max_tokens", config.doubao_chat?.max_tokens || 256);
-      setVal("cfg_doubao_temperature", config.doubao_chat?.temperature ?? 0.7);
-      setVal("cfg_doubao_system_prompt", config.doubao_chat?.system_prompt || "");
-
-      setVal("cfg_doubao_context_rounds", config.doubao_chat?.context_max_rounds ?? 0);
-      setVal("cfg_doubao_context_ttl", config.doubao_chat?.context_ttl_seconds ?? 0);
-
-      setVal("cfg_doubao_img_enabled", config.doubao_image?.enabled);
-      setVal("cfg_doubao_img_base_url", config.doubao_image?.base_url || "");
-      setVal("cfg_doubao_img_model", config.doubao_image?.model || "");
-      setVal("cfg_doubao_img_size", config.doubao_image?.size || "");
-      setVal("cfg_doubao_img_watermark", config.doubao_image?.watermark);
-
-      setVal("cfg_music_auto_play", config.music?.auto_play_enabled);
-      setVal("cfg_music_volume", config.music?.default_volume ?? 50);
-
-      setVal("cfg_qq_music_enabled", config.qq_music?.enabled);
-      setVal("cfg_qq_music_base_url", config.qq_music?.base_url || "");
-
-      setVal("cfg_bilibili_enabled", config.bilibili_music?.enabled);
-
-      setVal("cfg_stats_enabled", config.message_stats?.enabled);
-
-      setVal("cfg_cooldown_enabled", config.command_cooldown?.enabled);
-      setVal("cfg_cooldown_seconds", config.command_cooldown?.default_seconds ?? 3);
-      setVal("cfg_cooldown_exempt_admins", config.command_cooldown?.exempt_admins);
-
-      setVal("cfg_scheduler_enabled", config.scheduler?.enabled);
-      setVal("cfg_scheduler_interval", config.scheduler?.check_interval_seconds ?? 30);
-      setVal("cfg_reminder_enabled", config.reminder?.enabled);
-      setVal("cfg_reminder_max_per_user", config.reminder?.max_per_user ?? 5);
-      setVal("cfg_reminder_max_delay", config.reminder?.max_delay_hours ?? 72);
-      setVal("cfg_reminder_interval", config.reminder?.check_interval_seconds ?? 15);
-
-      setVal("cfg_notify_join_tpl", config.area_join_notify?.message_template || "");
-      setVal("cfg_notify_leave_tpl", config.area_join_notify?.message_template_leave || "");
-
+      // 密钥字段：仅展示是否已配置，不回填明文（Cookie 类回填便于复用）。
       setSecretState("cfg_admin_password", config.web_player?.admin_password_configured);
       setSecretState("cfg_oopz_login_password", config.oopz?.login_password_configured);
       setSecretValue("cfg_netease_cookie", config.netease?.cookie || "", config.netease?.cookie_configured);
@@ -720,8 +694,8 @@
       setSecretValue("cfg_doubao_img_api_key", config.doubao_image?.api_key || "", config.doubao_image?.api_key_configured);
       setSecretValue("cfg_qq_music_cookie", config.qq_music?.cookie || "", config.qq_music?.cookie_configured);
       setSecretValue("cfg_bilibili_cookie", config.bilibili_music?.cookie || "", config.bilibili_music?.cookie_configured);
-      setNeteaseQrSaveEnabled(false);
-      setBilibiliQrSaveEnabled(false);
+      neteaseQr.setSaveEnabled(false);
+      bilibiliQr.setSaveEnabled(false);
       renderMusicAreaHint(runtime.music_area || {});
       await loadNeteaseAccountStatus(!!config.netease?.cookie_configured);
       await loadBilibiliAccountStatus(!!config.bilibili_music?.cookie_configured);
@@ -730,117 +704,16 @@
     }
 
     function build() {
-      var keywordsObj = window._kwCollect();
+      const updates = {};
+      CONFIG_FIELDS.forEach(function (field) {
+        _buildField(updates, field);
+      });
 
-      const updates = {
-        web_player: {
-          url: val("cfg_web_url"),
-          host: val("cfg_web_host") || "0.0.0.0",
-          port: getInt("cfg_web_port") || 8080,
-          token_ttl_seconds: getInt("cfg_web_token_ttl"),
-          cookie_max_age_seconds: getInt("cfg_web_cookie_age"),
-          link_idle_release_seconds: getInt("cfg_link_idle"),
-          cookie_secure: chk("cfg_cookie_secure"),
-          admin_session_ttl_seconds: getInt("cfg_admin_session_ttl"),
-          admin_cookie_secure: chk("cfg_admin_cookie_secure"),
-        },
-        auto_recall: {
-          enabled: chk("cfg_auto_recall_enabled"),
-          delay: getInt("cfg_auto_recall_delay"),
-          exclude_commands: val("cfg_auto_recall_exclude"),
-        },
-        area_join_notify: {
-          enabled: chk("cfg_area_notify_enabled"),
-          poll_interval_seconds: getInt("cfg_area_poll"),
-          message_template: val("cfg_notify_join_tpl"),
-          message_template_leave: val("cfg_notify_leave_tpl"),
-          auto_assign_role_id: val("cfg_area_auto_role_id"),
-          auto_assign_role_name: val("cfg_area_auto_role_name"),
-        },
-        chat: {
-          enabled: chk("cfg_chat_enabled"),
-          keyword_replies: keywordsObj,
-        },
-        profanity: {
-          enabled: chk("cfg_profanity_enabled"),
-          recall_message: chk("cfg_profanity_recall"),
-          mute_duration: getInt("cfg_mute_duration"),
-          warn_before_mute: chk("cfg_warn_before_mute"),
-          skip_admins: chk("cfg_skip_admins"),
-          context_detection: chk("cfg_context_detection"),
-          context_window: getInt("cfg_context_window"),
-          context_max_messages: getInt("cfg_context_max_messages"),
-          ai_detection: chk("cfg_ai_detection"),
-          ai_min_length: getInt("cfg_ai_min_length"),
-        },
-        oopz: {
-          login_phone: val("cfg_oopz_login_phone"),
-          login_password: val("cfg_oopz_login_password"),
-          default_area: val("cfg_oopz_default_area"),
-          default_channel: val("cfg_oopz_default_channel"),
-          proxy: val("cfg_oopz_proxy"),
-          agora_app_id: val("cfg_agora_app_id"),
-          agora_init_timeout: getInt("cfg_agora_timeout") || 1800,
-        },
-        netease: {
-          base_url: val("cfg_netease_base_url"),
-          audio_download_timeout: getInt("cfg_netease_timeout"),
-          audio_download_retries: getInt("cfg_netease_retries"),
-          audio_quality: val("cfg_netease_quality") || "standard",
-        },
-        redis: {
-          host: val("cfg_redis_host"),
-          port: getInt("cfg_redis_port"),
-          db: getInt("cfg_redis_db"),
-          decode_responses: chk("cfg_redis_decode"),
-        },
-        doubao_chat: {
-          enabled: chk("cfg_doubao_enabled"),
-          base_url: val("cfg_doubao_base_url"),
-          model: val("cfg_doubao_model"),
-          max_tokens: getInt("cfg_doubao_max_tokens"),
-          temperature: getFloat("cfg_doubao_temperature"),
-          system_prompt: val("cfg_doubao_system_prompt"),
-          context_max_rounds: getInt("cfg_doubao_context_rounds"),
-          context_ttl_seconds: getInt("cfg_doubao_context_ttl"),
-        },
-        doubao_image: {
-          enabled: chk("cfg_doubao_img_enabled"),
-          base_url: val("cfg_doubao_img_base_url"),
-          model: val("cfg_doubao_img_model"),
-          size: val("cfg_doubao_img_size"),
-          watermark: chk("cfg_doubao_img_watermark"),
-        },
-        music: {
-          auto_play_enabled: chk("cfg_music_auto_play"),
-          default_volume: getInt("cfg_music_volume"),
-        },
-        command_cooldown: {
-          enabled: chk("cfg_cooldown_enabled"),
-          default_seconds: getInt("cfg_cooldown_seconds"),
-          exempt_admins: chk("cfg_cooldown_exempt_admins"),
-        },
-        qq_music: {
-          enabled: chk("cfg_qq_music_enabled"),
-          base_url: val("cfg_qq_music_base_url"),
-        },
-        bilibili_music: {
-          enabled: chk("cfg_bilibili_enabled"),
-        },
-        message_stats: {
-          enabled: chk("cfg_stats_enabled"),
-        },
-        scheduler: {
-          enabled: chk("cfg_scheduler_enabled"),
-          check_interval_seconds: getInt("cfg_scheduler_interval"),
-        },
-        reminder: {
-          enabled: chk("cfg_reminder_enabled"),
-          max_per_user: getInt("cfg_reminder_max_per_user"),
-          max_delay_hours: getInt("cfg_reminder_max_delay"),
-          check_interval_seconds: getInt("cfg_reminder_interval"),
-        },
-      };
+      // 特殊字段：撤回排除命令为原始字符串（后端负责拆分）、关键词回复为键值对、
+      // OOPZ 登录密码始终随表单提交（不走「留空不修改」逻辑）。
+      _cfgSet(updates, "auto_recall.exclude_commands", val("cfg_auto_recall_exclude"));
+      _cfgSet(updates, "chat.keyword_replies", window._kwCollect());
+      _cfgSet(updates, "oopz.login_password", val("cfg_oopz_login_password"));
 
       const adminPassword = val("cfg_admin_password");
       const neteaseCookie = val("cfg_netease_cookie");
@@ -891,7 +764,7 @@
         await loadConfig();
       } catch (error) {
         AdminShell.showMessage("msg", error.message, true);
-        setPageState("配置保存失败", "error");
+        setPageState(error.message || "配置保存失败", "error");
       }
     }
 
@@ -903,6 +776,7 @@
         await loadConfig();
       } catch (error) {
         AdminShell.showMessage("msg", error.message, true);
+        setPageState(error.message || "恢复运行配置失败", "error");
       }
     }
 
@@ -918,6 +792,11 @@
       });
     }
 
+    AdminShell.registerActions({
+      "refresh-config": () => loadConfig(),
+      "reset-overrides": () => resetOverrides(),
+      "save-config": () => saveConfig(true),
+    });
     AdminShell.init({ page: "config", passwordHandler: login });
     initTabs();
     check();

--- a/src/web/assets/admin/pages/config_script.js
+++ b/src/web/assets/admin/pages/config_script.js
@@ -796,6 +796,13 @@
       "refresh-config": () => loadConfig(),
       "reset-overrides": () => resetOverrides(),
       "save-config": () => saveConfig(true),
+      "toggle-secret": (el) => toggleSecret(el.dataset.secret, el),
+      "kw-add": () => window._kwAdd(),
+      "oopz-login": () => loginOopzAccount(),
+      "netease-qr-refresh": () => refreshNeteaseQr(),
+      "netease-qr-save": () => saveNeteaseQrCookie(true),
+      "bilibili-qr-refresh": () => refreshBilibiliQr(),
+      "bilibili-qr-save": () => saveBilibiliQrCookie(true),
     });
     AdminShell.init({ page: "config", passwordHandler: login });
     initTabs();

--- a/src/web/assets/admin/pages/dashboard_content.html
+++ b/src/web/assets/admin/pages/dashboard_content.html
@@ -3,9 +3,9 @@
           <article class="surface-card">
             <div class="action-row">
               <span id="overviewLiveHint" class="micro-status is-warning">等待连接</span>
-              <button class="btn btn-primary" type="button" onclick="loadOverview().catch(() => {})">同步</button>
-              <button class="btn btn-ghost" type="button" onclick="startOverviewStream()">恢复实时流</button>
-              <button class="btn btn-ghost" type="button" onclick="stopOverviewStream()">暂停实时流</button>
+              <button class="btn btn-primary" type="button" data-action="refresh-overview">同步</button>
+              <button class="btn btn-ghost" type="button" data-action="stream-resume">恢复实时流</button>
+              <button class="btn btn-ghost" type="button" data-action="stream-pause">暂停实时流</button>
             </div>
           </article>
 

--- a/src/web/assets/admin/pages/dashboard_script.js
+++ b/src/web/assets/admin/pages/dashboard_script.js
@@ -126,6 +126,9 @@
       await check();
     }
 
+    AdminShell.registerActions({
+      "refresh-overview": () => loadOverview(),
+    });
     AdminShell.init({ page: "dashboard", passwordHandler: login });
     check();
 

--- a/src/web/assets/admin/pages/dashboard_script.js
+++ b/src/web/assets/admin/pages/dashboard_script.js
@@ -128,6 +128,8 @@
 
     AdminShell.registerActions({
       "refresh-overview": () => loadOverview(),
+      "stream-resume": () => startOverviewStream(),
+      "stream-pause": () => stopOverviewStream(),
     });
     AdminShell.init({ page: "dashboard", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/members_content.html
+++ b/src/web/assets/admin/pages/members_content.html
@@ -2,10 +2,10 @@
         <article class="surface-card">
           <div class="action-row" style="flex-wrap:wrap">
             <span id="membersState" class="micro-status is-warning">等待同步</span>
-            <select id="areaPicker" class="m-area-select" onchange="onAreaChange()">
+            <select id="areaPicker" class="m-area-select" data-change="area-change">
               <option value="">加载中...</option>
             </select>
-            <input id="memberSearch" type="text" class="input" placeholder="搜索成员..." style="width:180px" onkeydown="if(event.key==='Enter')loadMembers()">
+            <input id="memberSearch" type="text" class="input" placeholder="搜索成员..." style="width:180px" data-enter="refresh-members">
             <button class="btn btn-ghost" type="button" data-action="refresh-members">搜索</button>
             <button class="btn btn-ghost" type="button" data-action="load-blocks">封禁列表</button>
           </div>
@@ -83,7 +83,7 @@
               <div class="m-send-field">
                 <label class="m-send-field__label">目标域</label>
                 <div class="m-select-wrap">
-                  <select id="sendAreaPicker" class="m-select" onchange="onSendAreaChange()">
+                  <select id="sendAreaPicker" class="m-select" data-change="send-area-change">
                     <option value="">加载中...</option>
                   </select>
                   <span class="m-select-arrow"></span>

--- a/src/web/assets/admin/pages/members_content.html
+++ b/src/web/assets/admin/pages/members_content.html
@@ -6,8 +6,8 @@
               <option value="">加载中...</option>
             </select>
             <input id="memberSearch" type="text" class="input" placeholder="搜索成员..." style="width:180px" onkeydown="if(event.key==='Enter')loadMembers()">
-            <button class="btn btn-ghost" type="button" onclick="loadMembers()">搜索</button>
-            <button class="btn btn-ghost" type="button" onclick="loadBlocks()">封禁列表</button>
+            <button class="btn btn-ghost" type="button" data-action="refresh-members">搜索</button>
+            <button class="btn btn-ghost" type="button" data-action="load-blocks">封禁列表</button>
           </div>
         </article>
 
@@ -46,9 +46,9 @@
             </table>
           </div>
           <div class="action-row" style="justify-content:center;gap:8px;padding-top:8px">
-            <button class="btn btn-ghost" type="button" onclick="prevPage()">上一页</button>
+            <button class="btn btn-ghost" type="button" data-action="members-prev">上一页</button>
             <span id="pageInfo" style="line-height:32px;font-size:13px;color:#94a3b8">1</span>
-            <button class="btn btn-ghost" type="button" onclick="nextPage()">下一页</button>
+            <button class="btn btn-ghost" type="button" data-action="members-next">下一页</button>
           </div>
         </article>
 
@@ -99,7 +99,7 @@
                   <span class="m-select-arrow"></span>
                 </div>
               </div>
-              <button class="m-send-refresh" type="button" onclick="refreshChannels()" title="刷新频道列表">
+              <button class="m-send-refresh" type="button" data-action="refresh-channels" title="刷新频道列表">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M13.65 2.35A7.96 7.96 0 008 0C3.58 0 .01 3.58.01 8S3.58 16 8 16c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 018 14 6 6 0 012 8a6 6 0 016-6c1.66 0 3.14.69 4.22 1.78L9 7h7V0l-2.35 2.35z" fill="currentColor"/></svg>
               </button>
             </div>
@@ -108,11 +108,11 @@
             </div>
             <div class="m-send-bar">
               <span id="sendStatus" class="m-send-status"></span>
-              <button class="m-send-btn m-send-btn--normal" type="button" onclick="doSendMessage()">
+              <button class="m-send-btn m-send-btn--normal" type="button" data-action="send-message">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" style="margin-right:4px"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" fill="currentColor"/></svg>
                 发送消息
               </button>
-              <button class="m-send-btn m-send-btn--announce" type="button" onclick="doSendAnnouncement()">
+              <button class="m-send-btn m-send-btn--announce" type="button" data-action="send-announcement">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" style="margin-right:4px"><path d="M18 11v2h4v-2h-4zm-2 6.61c.96.71 2.21 1.65 3.2 2.39.4-.53.8-1.07 1.2-1.6-.99-.74-2.24-1.68-3.2-2.4-.4.54-.8 1.08-1.2 1.61zM20.4 5.6c-.4-.53-.8-1.07-1.2-1.6-.99.74-2.24 1.68-3.2 2.4.4.53.8 1.07 1.2 1.6.96-.72 2.21-1.65 3.2-2.4zM4 9c-1.1 0-2 .9-2 2v2c0 1.1.9 2 2 2h1l5 5V4L5 9H4zm11.5 3c0-1.33-.58-2.53-1.5-3.35v6.69c.92-.81 1.5-2.01 1.5-3.34z" fill="currentColor"/></svg>
                 发送公告
               </button>
@@ -121,11 +121,11 @@
         </article>
 
         <!-- 用户详情抽屉 -->
-        <div id="drawerOverlay" class="m-drawer-overlay" onclick="closeDrawer()"></div>
+        <div id="drawerOverlay" class="m-drawer-overlay" data-action="close-drawer"></div>
         <aside id="detailDrawer" class="m-drawer">
           <header class="m-drawer__head">
             <h3 id="detailName" class="m-drawer__title">用户详情</h3>
-            <button class="m-drawer__close" onclick="closeDrawer()" aria-label="关闭">&times;</button>
+            <button class="m-drawer__close" type="button" data-action="close-drawer" aria-label="关闭">&times;</button>
           </header>
           <div class="m-drawer__body">
             <div id="detailProfile" class="m-profile"></div>
@@ -136,11 +136,11 @@
         </aside>
 
         <!-- 自定义弹窗 -->
-        <div id="modalOverlay" class="m-modal-overlay" onclick="AdminShell.closeModal()"></div>
+        <div id="modalOverlay" class="m-modal-overlay" data-action="close-modal"></div>
         <div id="modalDialog" class="m-modal">
           <header class="m-modal__head">
             <h3 id="modalTitle" class="m-modal__title">操作</h3>
-            <button class="m-modal__close" onclick="AdminShell.closeModal()" aria-label="关闭">&times;</button>
+            <button class="m-modal__close" type="button" data-action="close-modal" aria-label="关闭">&times;</button>
           </header>
           <div id="modalBody" class="m-modal__body"></div>
           <footer id="modalFooter" class="m-modal__foot"></footer>

--- a/src/web/assets/admin/pages/members_content.html
+++ b/src/web/assets/admin/pages/members_content.html
@@ -136,11 +136,11 @@
         </aside>
 
         <!-- 自定义弹窗 -->
-        <div id="modalOverlay" class="m-modal-overlay" onclick="closeModal()"></div>
+        <div id="modalOverlay" class="m-modal-overlay" onclick="AdminShell.closeModal()"></div>
         <div id="modalDialog" class="m-modal">
           <header class="m-modal__head">
             <h3 id="modalTitle" class="m-modal__title">操作</h3>
-            <button class="m-modal__close" onclick="closeModal()" aria-label="关闭">&times;</button>
+            <button class="m-modal__close" onclick="AdminShell.closeModal()" aria-label="关闭">&times;</button>
           </header>
           <div id="modalBody" class="m-modal__body"></div>
           <footer id="modalFooter" class="m-modal__foot"></footer>

--- a/src/web/assets/admin/pages/members_script.js
+++ b/src/web/assets/admin/pages/members_script.js
@@ -669,6 +669,8 @@
       "remove-admin": (el) => doRemoveAdmin(el.dataset.uid),
       "role-add": (el) => doRoleAdd(el.dataset.uid, Number(el.dataset.rid)),
       "role-remove": (el) => doRoleRemove(el.dataset.uid, Number(el.dataset.rid)),
+      "area-change": () => onAreaChange(),
+      "send-area-change": () => onSendAreaChange(),
     });
     AdminShell.init({ page: "members", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/members_script.js
+++ b/src/web/assets/admin/pages/members_script.js
@@ -1,8 +1,16 @@
     var currentOffset = 0;
     var pageSize = 50;
     var totalMembers = 0;
-    var _modalResolve = null;
     var currentArea = "";
+
+    var MUTE_PRESETS = [
+      { min: 1, val: "1", unit: "分钟" },
+      { min: 5, val: "5", unit: "分钟" },
+      { min: 60, val: "1", unit: "小时" },
+      { min: 1440, val: "1", unit: "天" },
+      { min: 4320, val: "3", unit: "天" },
+      { min: 10080, val: "7", unit: "天" },
+    ];
 
     function getArea() { return currentArea; }
 
@@ -48,64 +56,42 @@
 
     /* ========= 自定义弹窗 ========= */
 
-    function openModal(title, bodyHtml, footerHtml) {
-      AdminShell.byId("modalTitle").textContent = title;
-      AdminShell.byId("modalBody").innerHTML = bodyHtml;
-      AdminShell.byId("modalFooter").innerHTML = footerHtml || "";
-      AdminShell.byId("modalOverlay").classList.add("is-open");
-      AdminShell.byId("modalDialog").classList.add("is-open");
-    }
-
-    function closeModal() {
-      var dialog = AdminShell.byId("modalDialog");
-      var overlay = AdminShell.byId("modalOverlay");
-      dialog.classList.remove("is-open");
-      overlay.classList.remove("is-open");
-      if (_modalResolve) { _modalResolve(null); _modalResolve = null; }
-    }
-
     function pickDuration(type) {
       var label = type === "mic" ? "禁麦" : "禁言";
-      var options = [
-        { min: 1, val: "1", unit: "分钟" },
-        { min: 5, val: "5", unit: "分钟" },
-        { min: 60, val: "1", unit: "小时" },
-        { min: 1440, val: "1", unit: "天" },
-        { min: 4320, val: "3", unit: "天" },
-        { min: 10080, val: "7", unit: "天" },
-      ];
-      var grid = '<div class="m-duration-grid">' + options.map(function (o) {
-        return '<button class="m-duration-btn" onclick="_modalResolve(' + o.min + ');closeModal()">' +
-          '<span class="m-duration-btn__val">' + o.val + '</span>' +
-          '<span class="m-duration-btn__unit">' + o.unit + '</span>' +
-          '</button>';
-      }).join("") + '</div>';
-
       return new Promise(function (resolve) {
-        _modalResolve = resolve;
-        openModal(label + "时长", grid, '<button class="btn btn-ghost" onclick="closeModal()">取消</button>');
-      });
-    }
+        var settled = false;
+        function done(value) {
+          if (settled) return;
+          settled = true;
+          AdminShell.closeModal();
+          resolve(value);
+        }
+        var grid = document.createElement("div");
+        grid.className = "m-duration-grid";
+        MUTE_PRESETS.forEach(function (preset) {
+          var btn = document.createElement("button");
+          btn.className = "m-duration-btn";
+          btn.innerHTML =
+            '<span class="m-duration-btn__val">' + preset.val + "</span>" +
+            '<span class="m-duration-btn__unit">' + preset.unit + "</span>";
+          btn.addEventListener("click", function () { done(preset.min); });
+          grid.appendChild(btn);
+        });
 
-    function confirmAction(title, message) {
-      return new Promise(function (resolve) {
-        _modalResolve = function () { resolve(false); };
-        var body = '<div class="m-confirm-text">' + message + '</div>';
-        var foot =
-          '<button class="btn btn-ghost" onclick="closeModal()">取消</button>' +
-          '<button class="btn btn-danger" onclick="_modalResolve=null;closeModal();(' + resolve.name + ' || arguments.callee).__cb(true)">确认</button>';
-        openModal(title, body, '');
-        AdminShell.byId("modalFooter").innerHTML = "";
-        var cancelBtn = document.createElement("button");
-        cancelBtn.className = "btn btn-ghost";
-        cancelBtn.textContent = "取消";
-        cancelBtn.onclick = function () { closeModal(); resolve(false); };
-        var okBtn = document.createElement("button");
-        okBtn.className = "btn btn-danger";
-        okBtn.textContent = "确认";
-        okBtn.onclick = function () { _modalResolve = null; closeModal(); resolve(true); };
-        AdminShell.byId("modalFooter").appendChild(cancelBtn);
-        AdminShell.byId("modalFooter").appendChild(okBtn);
+        AdminShell.openModal(label + "时长", "", null, function () {
+          if (!settled) { settled = true; resolve(0); }
+        });
+        var bodyEl = AdminShell.byId("modalBody");
+        if (bodyEl) { bodyEl.innerHTML = ""; bodyEl.appendChild(grid); }
+        var footEl = AdminShell.byId("modalFooter");
+        if (footEl) {
+          footEl.innerHTML = "";
+          var cancelBtn = document.createElement("button");
+          cancelBtn.className = "btn btn-ghost";
+          cancelBtn.textContent = "取消";
+          cancelBtn.addEventListener("click", function () { done(0); });
+          footEl.appendChild(cancelBtn);
+        }
       });
     }
 
@@ -406,7 +392,7 @@
     }
 
     async function doKick(uid) {
-      var ok = await confirmAction("踢出用户", "确认将该用户<strong>踢出域</strong>？此操作不可撤销。");
+      var ok = await AdminShell.confirm("踢出用户", "确认将该用户<strong>踢出域</strong>？此操作不可撤销。");
       if (!ok) return;
       try {
         await AdminShell.req("/admin/api/members/" + uid + "/kick", { method: "POST", body: JSON.stringify({ area: getArea() }) });
@@ -417,7 +403,7 @@
     }
 
     async function doBlock(uid) {
-      var ok = await confirmAction("封禁用户", "确认<strong>封禁</strong>该用户？封禁后将被踢出域且无法再加入。");
+      var ok = await AdminShell.confirm("封禁用户", "确认<strong>封禁</strong>该用户？封禁后将被踢出域且无法再加入。");
       if (!ok) return;
       try {
         await AdminShell.req("/admin/api/members/" + uid + "/block", { method: "POST", body: JSON.stringify({ area: getArea() }) });
@@ -460,7 +446,7 @@
     /* ========= Bot 管理员操作 ========= */
 
     async function doGrantAdmin(uid) {
-      var ok = await confirmAction("设为管理员", "确认将该用户设为 <strong>Bot 管理员</strong>？管理员可执行所有管理命令。");
+      var ok = await AdminShell.confirm("设为管理员", "确认将该用户设为 <strong>Bot 管理员</strong>？管理员可执行所有管理命令。");
       if (!ok) return;
       try {
         await AdminShell.req("/admin/api/bot-admins", {
@@ -473,7 +459,7 @@
     }
 
     async function doRemoveAdmin(uid) {
-      var ok = await confirmAction("撤销管理员", "确认<strong>撤销</strong>该用户的 Bot 管理员权限？");
+      var ok = await AdminShell.confirm("撤销管理员", "确认<strong>撤销</strong>该用户的 Bot 管理员权限？");
       if (!ok) return;
       try {
         await AdminShell.req("/admin/api/bot-admins/" + uid, { method: "DELETE" });
@@ -662,5 +648,8 @@
       await check();
     }
 
+    AdminShell.registerActions({
+      "refresh-members": () => loadMembers(),
+    });
     AdminShell.init({ page: "members", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/members_script.js
+++ b/src/web/assets/admin/pages/members_script.js
@@ -144,9 +144,9 @@
               '<td>' + roleHtml + '</td>' +
               '<td>' + statusLabel + '</td>' +
               '<td><div class="m-member-actions">' +
-                '<button class="btn btn-ghost" onclick="showDetail(\'' + esc(m.uid) + '\')">详情</button>' +
-                '<button class="btn btn-ghost" onclick="doMute(\'' + esc(m.uid) + '\')">禁言</button>' +
-                '<button class="btn btn-danger btn-sm" onclick="doKick(\'' + esc(m.uid) + '\')">踢出</button>' +
+                '<button class="btn btn-ghost" type="button" data-action="show-detail" data-uid="' + esc(m.uid) + '">详情</button>' +
+                '<button class="btn btn-ghost" type="button" data-action="do-mute" data-uid="' + esc(m.uid) + '">禁言</button>' +
+                '<button class="btn btn-danger btn-sm" type="button" data-action="do-kick" data-uid="' + esc(m.uid) + '">踢出</button>' +
               '</div></td>' +
             "</tr>"
           );
@@ -276,22 +276,22 @@
         // action buttons
         var actions = '';
         if (data.is_bot_admin) {
-          actions += '<button class="btn btn-ghost m-btn--admin-revoke" onclick="doRemoveAdmin(\'' + esc(uid) + '\')">撤销管理员</button>';
+          actions += '<button class="btn btn-ghost m-btn--admin-revoke" type="button" data-action="remove-admin" data-uid="' + esc(uid) + '">撤销管理员</button>';
         } else {
-          actions += '<button class="btn btn-ghost m-btn--admin-grant" onclick="doGrantAdmin(\'' + esc(uid) + '\')">设为管理员</button>';
+          actions += '<button class="btn btn-ghost m-btn--admin-grant" type="button" data-action="grant-admin" data-uid="' + esc(uid) + '">设为管理员</button>';
         }
         if (data.muted) {
-          actions += '<button class="btn btn-ghost" onclick="doUnmute(\'' + esc(uid) + '\')">解除禁言</button>';
+          actions += '<button class="btn btn-ghost" type="button" data-action="do-unmute" data-uid="' + esc(uid) + '">解除禁言</button>';
         } else {
-          actions += '<button class="btn btn-ghost" onclick="doMute(\'' + esc(uid) + '\')">禁言</button>';
+          actions += '<button class="btn btn-ghost" type="button" data-action="do-mute" data-uid="' + esc(uid) + '">禁言</button>';
         }
         if (data.mic_muted) {
-          actions += '<button class="btn btn-ghost" onclick="doUnmuteMic(\'' + esc(uid) + '\')">解除禁麦</button>';
+          actions += '<button class="btn btn-ghost" type="button" data-action="do-unmute-mic" data-uid="' + esc(uid) + '">解除禁麦</button>';
         } else {
-          actions += '<button class="btn btn-ghost" onclick="doMuteMic(\'' + esc(uid) + '\')">禁麦</button>';
+          actions += '<button class="btn btn-ghost" type="button" data-action="do-mute-mic" data-uid="' + esc(uid) + '">禁麦</button>';
         }
-        actions += '<button class="btn btn-danger" onclick="doKick(\'' + esc(uid) + '\')">踢出</button>';
-        actions += '<button class="btn btn-danger" onclick="doBlock(\'' + esc(uid) + '\')">封禁</button>';
+        actions += '<button class="btn btn-danger" type="button" data-action="do-kick" data-uid="' + esc(uid) + '">踢出</button>';
+        actions += '<button class="btn btn-danger" type="button" data-action="do-block" data-uid="' + esc(uid) + '">封禁</button>';
         AdminShell.byId("detailActions").innerHTML = actions;
 
         // assignable roles
@@ -304,10 +304,10 @@
             var rname = esc(r.name || rid);
             var hasRole = roles.some(function (ur) { return (ur.roleID || ur.id) == rid; });
             if (hasRole) {
-              roleSection += '<span class="m-role-tag m-role-tag--owned" onclick="doRoleRemove(\'' + esc(uid) + '\',' + rid + ')" title="点击移除">' +
+              roleSection += '<span class="m-role-tag m-role-tag--owned" data-action="role-remove" data-uid="' + esc(uid) + '" data-rid="' + rid + '" title="点击移除">' +
                 rname + ' <span class="m-role-tag__icon">&times;</span></span>';
             } else {
-              roleSection += '<span class="m-role-tag" onclick="doRoleAdd(\'' + esc(uid) + '\',' + rid + ')" title="点击添加">' +
+              roleSection += '<span class="m-role-tag" data-action="role-add" data-uid="' + esc(uid) + '" data-rid="' + rid + '" title="点击添加">' +
                 rname + ' <span class="m-role-tag__icon">+</span></span>';
             }
           });
@@ -484,7 +484,7 @@
               '<td class="table-emphasis">' + esc(b.name) + "</td>" +
               "<td style=\"font-size:12px;color:var(--ink-faint)\">" + esc((b.uid || "").slice(0, 12)) + "...</td>" +
               "<td>" +
-                '<button class="btn btn-ghost btn-sm" onclick="doUnblock(\'' + esc(b.uid) + '\')">解封</button>' +
+                '<button class="btn btn-ghost btn-sm" type="button" data-action="do-unblock" data-uid="' + esc(b.uid) + '">解封</button>' +
               "</td>" +
             "</tr>"
           );
@@ -650,6 +650,25 @@
 
     AdminShell.registerActions({
       "refresh-members": () => loadMembers(),
+      "load-blocks": () => loadBlocks(),
+      "members-prev": () => prevPage(),
+      "members-next": () => nextPage(),
+      "refresh-channels": () => refreshChannels(),
+      "send-message": () => doSendMessage(),
+      "send-announcement": () => doSendAnnouncement(),
+      "close-drawer": () => closeDrawer(),
+      "show-detail": (el) => showDetail(el.dataset.uid),
+      "do-mute": (el) => doMute(el.dataset.uid),
+      "do-unmute": (el) => doUnmute(el.dataset.uid),
+      "do-mute-mic": (el) => doMuteMic(el.dataset.uid),
+      "do-unmute-mic": (el) => doUnmuteMic(el.dataset.uid),
+      "do-kick": (el) => doKick(el.dataset.uid),
+      "do-block": (el) => doBlock(el.dataset.uid),
+      "do-unblock": (el) => doUnblock(el.dataset.uid),
+      "grant-admin": (el) => doGrantAdmin(el.dataset.uid),
+      "remove-admin": (el) => doRemoveAdmin(el.dataset.uid),
+      "role-add": (el) => doRoleAdd(el.dataset.uid, Number(el.dataset.rid)),
+      "role-remove": (el) => doRoleRemove(el.dataset.uid, Number(el.dataset.rid)),
     });
     AdminShell.init({ page: "members", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/music_content.html
+++ b/src/web/assets/admin/pages/music_content.html
@@ -2,11 +2,11 @@
         <article class="surface-card">
           <div class="action-row">
             <span id="ctlState" class="micro-status is-neutral">等待操作</span>
-            <button class="btn" type="button" onclick="control('pause')">暂停</button>
-            <button class="btn" type="button" onclick="control('resume')">恢复</button>
-            <button class="btn" type="button" onclick="control('next')">下一首</button>
-            <button class="btn btn-danger" type="button" onclick="control('stop')">停止</button>
-            <button class="btn btn-danger" type="button" onclick="clearQueue()">清空队列</button>
+            <button class="btn" type="button" data-action="control" data-control="pause">暂停</button>
+            <button class="btn" type="button" data-action="control" data-control="resume">恢复</button>
+            <button class="btn" type="button" data-action="control" data-control="next">下一首</button>
+            <button class="btn btn-danger" type="button" data-action="control" data-control="stop">停止</button>
+            <button class="btn btn-danger" type="button" data-action="clear-queue">清空队列</button>
           </div>
           <div class="action-row" style="margin-top: 12px;">
             <span id="musicAreaState" class="micro-status is-warning">域未解析</span>
@@ -26,7 +26,7 @@
             </div>
             <div class="action-row">
               <input id="kw" type="text" placeholder="输入关键词搜索歌曲" />
-              <button class="btn btn-primary" type="button" onclick="searchSongs(true)">搜索</button>
+              <button class="btn btn-primary" type="button" data-action="search-songs">搜索</button>
             </div>
             <div class="table-shell" style="margin-top: 18px;">
               <table>
@@ -46,8 +46,8 @@
               </table>
             </div>
             <div class="action-row" style="margin-top: 14px;">
-              <button class="btn btn-sm btn-ghost" type="button" onclick="changeSearch(-1)">上一页</button>
-              <button class="btn btn-sm btn-ghost" type="button" onclick="changeSearch(1)">下一页</button>
+              <button class="btn btn-sm btn-ghost" type="button" data-action="change-search" data-delta="-1">上一页</button>
+              <button class="btn btn-sm btn-ghost" type="button" data-action="change-search" data-delta="1">下一页</button>
               <span id="searchInfo" class="mono"></span>
             </div>
             <div id="searchMsg" class="msg"></div>
@@ -78,8 +78,8 @@
               </table>
             </div>
             <div class="action-row" style="margin-top: 14px;">
-              <button class="btn btn-sm btn-ghost" type="button" onclick="changeQueue(-1)">上一页</button>
-              <button class="btn btn-sm btn-ghost" type="button" onclick="changeQueue(1)">下一页</button>
+              <button class="btn btn-sm btn-ghost" type="button" data-action="change-queue" data-delta="-1">上一页</button>
+              <button class="btn btn-sm btn-ghost" type="button" data-action="change-queue" data-delta="1">下一页</button>
               <span id="queueInfo" class="mono"></span>
             </div>
             <div id="queueMsg" class="msg"></div>

--- a/src/web/assets/admin/pages/music_script.js
+++ b/src/web/assets/admin/pages/music_script.js
@@ -134,8 +134,8 @@
             "<td>" + escapeHtml(item.durationText || "-") + "</td>" +
             "<td>" +
               '<div class="action-row">' +
-                '<button class="btn btn-sm btn-ghost" type="button" onclick="queueAction(\'top\', ' + item.index + ')">置顶</button>' +
-                '<button class="btn btn-sm btn-danger" type="button" onclick="queueAction(\'remove\', ' + item.index + ')">删除</button>' +
+                '<button class="btn btn-sm btn-ghost" type="button" data-action="queue-action" data-queue-action="top" data-index="' + item.index + '">置顶</button>' +
+                '<button class="btn btn-sm btn-danger" type="button" data-action="queue-action" data-queue-action="remove" data-index="' + item.index + '">删除</button>' +
               "</div>" +
             "</td>" +
           "</tr>"
@@ -195,7 +195,7 @@
                   "<td>" + escapeHtml(item.name || "-") + "</td>" +
                   "<td>" + escapeHtml(item.artists || "-") + "</td>" +
                   "<td>" + escapeHtml(item.album || "-") + "</td>" +
-                  '<td><button class="btn btn-sm btn-primary" type="button" onclick="addSong(' + index + ')">加入队列</button></td>' +
+                  '<td><button class="btn btn-sm btn-primary" type="button" data-action="add-song" data-index="' + index + '">加入队列</button></td>' +
                 "</tr>"
               );
             })
@@ -235,5 +235,15 @@
       }
     }
 
+    AdminShell.registerActions({
+      "refresh-queue": () => loadQueue(),
+      "control": (el) => control(el.dataset.control),
+      "clear-queue": () => clearQueue(),
+      "search-songs": () => searchSongs(true),
+      "change-search": (el) => changeSearch(Number(el.dataset.delta)),
+      "change-queue": (el) => changeQueue(Number(el.dataset.delta)),
+      "queue-action": (el) => queueAction(el.dataset.queueAction, Number(el.dataset.index)),
+      "add-song": (el) => addSong(Number(el.dataset.index)),
+    });
     AdminShell.init({ page: "music", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/plugins_content.html
+++ b/src/web/assets/admin/pages/plugins_content.html
@@ -59,11 +59,11 @@
         </article>
 
         <!-- 配置编辑模态框 -->
-        <div id="cfgOverlay" class="m-modal-overlay" onclick="closeConfigEditor()"></div>
+        <div id="cfgOverlay" class="m-modal-overlay" data-action="plugin-cfg-close"></div>
         <div id="cfgDialog" class="m-modal" style="width:min(760px,94vw)">
           <header class="m-modal__head">
             <h3 id="cfgTitle" class="m-modal__title">编辑插件配置</h3>
-            <button class="m-modal__close" onclick="closeConfigEditor()" aria-label="关闭">&times;</button>
+            <button class="m-modal__close" type="button" data-action="plugin-cfg-close" aria-label="关闭">&times;</button>
           </header>
           <div class="m-modal__body">
             <div id="cfgSchemaHint" class="p-schema-hint" style="display:none"></div>
@@ -75,8 +75,8 @@
             <div id="cfgMsg" class="msg" style="margin-top:8px"></div>
           </div>
           <footer class="m-modal__foot">
-            <button class="btn btn-ghost" type="button" onclick="closeConfigEditor()">取消</button>
-            <button class="btn btn-primary" type="button" onclick="saveConfig()">保存并重载</button>
+            <button class="btn btn-ghost" type="button" data-action="plugin-cfg-close">取消</button>
+            <button class="btn btn-primary" type="button" data-action="plugin-cfg-save">保存并重载</button>
           </footer>
         </div>
       </section>

--- a/src/web/assets/admin/pages/plugins_script.js
+++ b/src/web/assets/admin/pages/plugins_script.js
@@ -442,5 +442,8 @@
       }
     }
 
+    AdminShell.registerActions({
+      "refresh-plugins": () => loadPlugins(),
+    });
     AdminShell.init({ page: "plugins", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/plugins_script.js
+++ b/src/web/assets/admin/pages/plugins_script.js
@@ -78,10 +78,10 @@
 
             var actions = [];
             if (!p.builtin) {
-              actions.push('<button class="btn btn-danger" onclick="unloadPlugin(\'' + esc(p.name) + '\')">卸载</button>');
+              actions.push('<button class="btn btn-danger" type="button" data-action="unload-plugin" data-name="' + esc(p.name) + '">卸载</button>');
             }
-            actions.push('<button class="btn btn-ghost" onclick="reloadConfig(\'' + esc(p.name) + '\')">重载配置</button>');
-            actions.push('<button class="btn btn-ghost" onclick="openConfigEditor(\'' + esc(p.name) + '\')">编辑配置</button>');
+            actions.push('<button class="btn btn-ghost" type="button" data-action="reload-config" data-name="' + esc(p.name) + '">重载配置</button>');
+            actions.push('<button class="btn btn-ghost" type="button" data-action="open-config-editor" data-name="' + esc(p.name) + '">编辑配置</button>');
 
             return '<tr>' +
               '<td style="font-weight:600">' + esc(p.name) + '</td>' +
@@ -99,7 +99,7 @@
           availTbody.innerHTML = available.map(function (name) {
             return '<tr>' +
               '<td style="font-weight:600">' + esc(name) + '</td>' +
-              '<td><div class="p-actions"><button class="btn btn-primary" onclick="loadPlugin(\'' + esc(name) + '\')">加载</button></div></td>' +
+              '<td><div class="p-actions"><button class="btn btn-primary" type="button" data-action="load-plugin" data-name="' + esc(name) + '">加载</button></div></td>' +
               '</tr>';
           }).join("");
         } else {
@@ -444,6 +444,12 @@
 
     AdminShell.registerActions({
       "refresh-plugins": () => loadPlugins(),
+      "load-plugin": (el) => loadPlugin(el.dataset.name),
+      "unload-plugin": (el) => unloadPlugin(el.dataset.name),
+      "reload-config": (el) => reloadConfig(el.dataset.name),
+      "open-config-editor": (el) => openConfigEditor(el.dataset.name),
+      "plugin-cfg-close": () => closeConfigEditor(),
+      "plugin-cfg-save": () => saveConfig(),
     });
     AdminShell.init({ page: "plugins", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/scheduler_content.html
+++ b/src/web/assets/admin/pages/scheduler_content.html
@@ -2,7 +2,7 @@
         <article class="surface-card">
           <div class="action-row">
             <span id="schedulerState" class="micro-status is-warning">等待同步</span>
-            <button class="btn btn-primary" type="button" onclick="loadScheduler().catch(() => {})">刷新列表</button>
+            <button class="btn btn-primary" type="button" data-action="refresh-scheduler">刷新列表</button>
           </div>
         </article>
 
@@ -26,7 +26,7 @@
             </div>
             <textarea id="schText" rows="3" placeholder="消息内容" style="width: 100%;"></textarea>
             <div class="action-row">
-              <button class="btn btn-primary" type="button" onclick="createScheduled()">创建</button>
+              <button class="btn btn-primary" type="button" data-action="create-scheduled">创建</button>
               <span id="createMsg" class="msg"></span>
             </div>
           </div>

--- a/src/web/assets/admin/pages/scheduler_script.js
+++ b/src/web/assets/admin/pages/scheduler_script.js
@@ -256,5 +256,8 @@
       await check();
     }
 
+    AdminShell.registerActions({
+      "refresh-scheduler": () => loadScheduler(),
+    });
     AdminShell.init({ page: "scheduler", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/scheduler_script.js
+++ b/src/web/assets/admin/pages/scheduler_script.js
@@ -32,9 +32,9 @@
             "<td>" + weekdaysLabel(t.weekdays) + "</td>" +
             "<td>" + escapeHtml((t.message_text || "").slice(0, 40)) + "</td>" +
             "<td>" + status + "</td>" +
-            '<td><button class="btn btn-sm btn-ghost" onclick="toggleScheduled(' + t.id + ')">' +
+            '<td><button class="btn btn-sm btn-ghost" type="button" data-action="toggle-scheduled" data-id="' + t.id + '">' +
               (t.enabled ? "停用" : "启用") +
-            '</button> <button class="btn btn-sm btn-danger" onclick="deleteScheduled(' + t.id + ')">删除</button></td>' +
+            '</button> <button class="btn btn-sm btn-danger" type="button" data-action="delete-scheduled" data-id="' + t.id + '">删除</button></td>' +
           "</tr>"
         );
       }).join("");
@@ -75,8 +75,8 @@
               '<div>时间: ' + time + ' | ' + weekdaysLabel(item.weekdays) + '</div>' +
               '<div>内容: ' + escapeHtml((item.message_text || "").slice(0, 80)) + '</div>' +
               '<div class="action-row">' +
-                '<button class="btn btn-ghost" type="button" onclick="useTemplateToForm(\'' + escapeHtml(item.key) + '\')">套用到表单</button>' +
-                '<button class="btn btn-primary" type="button" onclick="createFromTemplate(\'' + escapeHtml(item.key) + '\')">一键创建</button>' +
+                '<button class="btn btn-ghost" type="button" data-action="use-template" data-key="' + escapeHtml(item.key) + '">套用到表单</button>' +
+                '<button class="btn btn-primary" type="button" data-action="create-from-template" data-key="' + escapeHtml(item.key) + '">一键创建</button>' +
               '</div>' +
             '</div>' +
           '</article>'
@@ -258,6 +258,11 @@
 
     AdminShell.registerActions({
       "refresh-scheduler": () => loadScheduler(),
+      "create-scheduled": () => createScheduled(),
+      "toggle-scheduled": (el) => toggleScheduled(Number(el.dataset.id)),
+      "delete-scheduled": (el) => deleteScheduled(Number(el.dataset.id)),
+      "use-template": (el) => useTemplateToForm(el.dataset.key),
+      "create-from-template": (el) => createFromTemplate(el.dataset.key),
     });
     AdminShell.init({ page: "scheduler", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/setup_content.html
+++ b/src/web/assets/admin/pages/setup_content.html
@@ -2,9 +2,9 @@
         <article class="surface-card">
           <div class="action-row">
             <span id="setupState" class="status-text is-warning">等待体检</span>
-            <button class="btn btn-primary" type="button" onclick="loadDiagnostics().catch(() => {})">开始体检</button>
-            <button class="btn btn-ghost" type="button" onclick="openAdminPage('/admin/config')">前往配置中心</button>
-            <button class="btn btn-ghost" type="button" onclick="openAdminPage('/admin/system')">查看系统页</button>
+            <button class="btn btn-primary" type="button" data-action="refresh-diagnostics">开始体检</button>
+            <button class="btn btn-ghost" type="button" data-action="open-page" data-page="/admin/config">前往配置中心</button>
+            <button class="btn btn-ghost" type="button" data-action="open-page" data-page="/admin/system">查看系统页</button>
           </div>
         </article>
 

--- a/src/web/assets/admin/pages/setup_script.js
+++ b/src/web/assets/admin/pages/setup_script.js
@@ -188,5 +188,8 @@
       await check();
     }
 
+    AdminShell.registerActions({
+      "refresh-diagnostics": () => loadDiagnostics(),
+    });
     AdminShell.init({ page: "setup", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/setup_script.js
+++ b/src/web/assets/admin/pages/setup_script.js
@@ -73,7 +73,7 @@
         const action = step.actions && step.actions.length ? escapeHtml(step.actions[0]) : "当前无需额外操作";
         const page = step.page || "";
         const button = page
-          ? `<button class="btn btn-ghost" type="button" onclick="openAdminPage('${escapeHtml(page)}')">打开页面</button>`
+          ? `<button class="btn btn-ghost" type="button" data-action="open-page" data-page="${escapeHtml(page)}">打开页面</button>`
           : "";
         return `
           <article class="surface-card">
@@ -107,7 +107,7 @@
       }
       root.innerHTML = items.map((item) => {
         const button = item.page
-          ? `<button class="btn btn-ghost btn-sm" type="button" onclick="openAdminPage('${escapeHtml(item.page)}')">打开</button>`
+          ? `<button class="btn btn-ghost btn-sm" type="button" data-action="open-page" data-page="${escapeHtml(item.page)}">打开</button>`
           : "";
         return `
           <tr>
@@ -190,6 +190,7 @@
 
     AdminShell.registerActions({
       "refresh-diagnostics": () => loadDiagnostics(),
+      "open-page": (el) => openAdminPage(el.dataset.page),
     });
     AdminShell.init({ page: "setup", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/stats_content.html
+++ b/src/web/assets/admin/pages/stats_content.html
@@ -2,8 +2,8 @@
         <article class="surface-card">
           <div class="action-row">
             <span id="statsState" class="micro-status is-warning">等待同步</span>
-            <button class="btn btn-primary" type="button" onclick="loadTop().catch(() => {})">刷新排行</button>
-            <button class="btn btn-danger" type="button" onclick="clearHistory()">清空历史</button>
+            <button class="btn btn-primary" type="button" data-action="refresh-stats">刷新排行</button>
+            <button class="btn btn-danger" type="button" data-action="clear-history">清空历史</button>
           </div>
         </article>
 
@@ -43,8 +43,8 @@
             </table>
           </div>
           <div class="action-row" style="margin-top: 14px;">
-            <button class="btn btn-sm btn-ghost" type="button" onclick="changeTop(-1)">上一页</button>
-            <button class="btn btn-sm btn-ghost" type="button" onclick="changeTop(1)">下一页</button>
+            <button class="btn btn-sm btn-ghost" type="button" data-action="change-top" data-delta="-1">上一页</button>
+            <button class="btn btn-sm btn-ghost" type="button" data-action="change-top" data-delta="1">下一页</button>
             <span id="topInfo" class="mono"></span>
           </div>
         </article>
@@ -56,7 +56,7 @@
             </div>
           </div>
           <div class="action-row">
-            <button class="btn btn-danger" type="button" onclick="clearHistory()">清空播放历史</button>
+            <button class="btn btn-danger" type="button" data-action="clear-history">清空播放历史</button>
           </div>
           <div id="msg" class="msg"></div>
         </article>

--- a/src/web/assets/admin/pages/stats_script.js
+++ b/src/web/assets/admin/pages/stats_script.js
@@ -102,6 +102,7 @@
     AdminShell.registerActions({
       "refresh-stats": () => loadTop(),
       "clear-history": () => clearHistory(),
+      "change-top": (el) => changeTop(Number(el.dataset.delta)),
     });
     AdminShell.init({ page: "stats", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/stats_script.js
+++ b/src/web/assets/admin/pages/stats_script.js
@@ -99,5 +99,9 @@
       }
     }
 
+    AdminShell.registerActions({
+      "refresh-stats": () => loadTop(),
+      "clear-history": () => clearHistory(),
+    });
     AdminShell.init({ page: "stats", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/system_content.html
+++ b/src/web/assets/admin/pages/system_content.html
@@ -2,10 +2,10 @@
         <article class="surface-card">
           <div class="action-row">
             <span id="logState" class="status-text is-warning">等待轮询</span>
-            <button class="btn btn-ghost" type="button" onclick="loadLink().catch(() => {})">刷新链接</button>
-            <button class="btn btn-ghost" type="button" onclick="loadSys().catch(() => {})">刷新系统信息</button>
-            <button class="btn" type="button" onclick="startLogPolling()">恢复轮询</button>
-            <button class="btn" type="button" onclick="stopLogPolling()">暂停轮询</button>
+            <button class="btn btn-ghost" type="button" data-action="refresh-link">刷新链接</button>
+            <button class="btn btn-ghost" type="button" data-action="refresh-system">刷新系统信息</button>
+            <button class="btn" type="button" data-action="log-resume">恢复轮询</button>
+            <button class="btn" type="button" data-action="log-pause">暂停轮询</button>
           </div>
         </article>
 
@@ -20,9 +20,9 @@
               <input id="playerLink" type="text" readonly placeholder="登录后生成播放器链接" />
             </div>
             <div class="action-row" style="margin-top: 16px;">
-              <button class="btn btn-ghost" type="button" onclick="loadLink()">刷新链接</button>
-              <button class="btn" type="button" onclick="copyLink()">复制链接</button>
-              <button class="btn btn-danger" type="button" onclick="rotateLink()">重置链接</button>
+              <button class="btn btn-ghost" type="button" data-action="refresh-link">刷新链接</button>
+              <button class="btn" type="button" data-action="copy-link">复制链接</button>
+              <button class="btn btn-danger" type="button" data-action="rotate-link">重置链接</button>
             </div>
             <div id="linkMsg" class="msg"></div>
           </article>
@@ -45,10 +45,10 @@
           </div>
           <pre id="logs" class="console">-</pre>
           <div class="action-row" style="margin-top: 16px;">
-            <button class="btn btn-ghost" type="button" onclick="loadLogs(200)">最近 200 行</button>
-            <button class="btn btn-ghost" type="button" onclick="loadLogs(800)">最近 800 行</button>
-            <button class="btn" type="button" onclick="startLogPolling()">恢复轮询</button>
-            <button class="btn" type="button" onclick="stopLogPolling()">暂停轮询</button>
+            <button class="btn btn-ghost" type="button" data-action="load-logs" data-lines="200">最近 200 行</button>
+            <button class="btn btn-ghost" type="button" data-action="load-logs" data-lines="800">最近 800 行</button>
+            <button class="btn" type="button" data-action="log-resume">恢复轮询</button>
+            <button class="btn" type="button" data-action="log-pause">暂停轮询</button>
           </div>
         </article>
       </section>

--- a/src/web/assets/admin/pages/system_script.js
+++ b/src/web/assets/admin/pages/system_script.js
@@ -136,6 +136,12 @@
     AdminShell.registerActions({
       "refresh-system": () => loadSys(),
       "refresh-logs": () => loadLogs(logTailSize),
+      "refresh-link": () => loadLink(),
+      "copy-link": () => copyLink(),
+      "rotate-link": () => rotateLink(),
+      "log-resume": () => startLogPolling(),
+      "log-pause": () => stopLogPolling(),
+      "load-logs": (el) => loadLogs(Number(el.dataset.lines)),
     });
     AdminShell.init({ page: "system", passwordHandler: login });
     check();

--- a/src/web/assets/admin/pages/system_script.js
+++ b/src/web/assets/admin/pages/system_script.js
@@ -133,6 +133,10 @@
       }
     }
 
+    AdminShell.registerActions({
+      "refresh-system": () => loadSys(),
+      "refresh-logs": () => loadLogs(logTailSize),
+    });
     AdminShell.init({ page: "system", passwordHandler: login });
     check();
 

--- a/tests/test_oopz_login_helpers.py
+++ b/tests/test_oopz_login_helpers.py
@@ -1,7 +1,9 @@
 import base64
 import json
+import os
 import sys
 import tempfile
+import threading
 import time
 import types
 import unittest
@@ -258,6 +260,15 @@ class OopzApiPasswordLoginTest(unittest.TestCase):
         self.assertIsNone(result)
         api_login.assert_not_called()
 
+    def test_config_login_account_accepts_legacy_phone_password_fields(self) -> None:
+        with patch.dict(os.environ, {"OOPZ_PHONE": "", "OOPZ_PASSWORD": ""}):
+            phone, password = password_login._config_login_account(
+                {"phone": "13800138000", "password": "plain-password"}
+            )
+
+        self.assertEqual(phone, "13800138000")
+        self.assertEqual(password, "plain-password")
+
 
 class OopzPasswordLoginFlowTest(unittest.IsolatedAsyncioTestCase):
     async def test_login_with_password_falls_back_to_browser_when_api_is_retryable(self) -> None:
@@ -351,6 +362,83 @@ class OopzClientCredentialsTest(unittest.TestCase):
             self.assertTrue(client._ws.closed)
 
         sys.modules.pop("oopz_client", None)
+
+
+class _SenderResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.content = b""
+        self.headers = {}
+
+
+class _SenderSession:
+    def __init__(self, responses):
+        self.headers = {}
+        self._responses = list(responses)
+        self.calls = []
+
+    def get(self, url, headers=None, params=None, timeout=None):
+        self.calls.append({
+            "method": "GET",
+            "url": url,
+            "headers": headers or {},
+            "params": params,
+            "timeout": timeout,
+        })
+        return self._responses.pop(0)
+
+
+class _SenderSigner:
+    def __init__(self):
+        self.private_key = "old-private-key"
+
+    def oopz_headers(self, url_path: str, body_str: str):
+        return {
+            "X-Signer-Key": self.private_key,
+            "X-Sign-Path": url_path,
+            "X-Sign-Body": body_str,
+        }
+
+
+class OopzSenderAuthRefreshTest(unittest.TestCase):
+    def test_get_refreshes_credentials_once_after_428_and_retries(self) -> None:
+        from oopz.oopz_sender import OopzSender
+
+        sender = OopzSender.__new__(OopzSender)
+        sender.signer = _SenderSigner()
+        sender.session = _SenderSession([_SenderResponse(428), _SenderResponse(200)])
+        sender._area_members_cache = {"stale": {"data": {}}}
+        sender._rate_lock = threading.Lock()
+        sender._auth_refresh_lock = threading.Lock()
+        sender._last_request_time = 0.0
+        sender._RATE_LIMIT_INTERVAL = 0.0
+
+        credentials = {
+            "person_uid": "person-new",
+            "device_id": "device-new",
+            "jwt_token": "jwt-new",
+            "private_key_pem": PRIVATE_KEY_PEM,
+            "app_version": "73817",
+        }
+
+        with (
+            patch(
+                "oopz.oopz_password_login.refresh_credentials_from_config_password",
+                return_value=credentials,
+            ) as refresh,
+            patch(
+                "oopz.oopz_password_login.load_private_key_from_pem",
+                return_value="new-private-key",
+            ),
+        ):
+            response = sender._get("/userSubscribeArea/v1/list")
+
+        self.assertEqual(response.status_code, 200)
+        refresh.assert_called_once_with(timeout=20, save=True)
+        self.assertEqual(len(sender.session.calls), 2)
+        self.assertEqual(sender.session.calls[0]["headers"]["X-Signer-Key"], "old-private-key")
+        self.assertEqual(sender.session.calls[1]["headers"]["X-Signer-Key"], "new-private-key")
+        self.assertEqual(sender._area_members_cache, {})
 
 
 if __name__ == "__main__":

--- a/tests/test_service_behavior.py
+++ b/tests/test_service_behavior.py
@@ -439,6 +439,49 @@ class RecallServiceTest(unittest.TestCase):
         self.assertEqual(self.sender.send_message.call_count, 2)
 
 
+class MessageRecallSchedulerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sender = Mock()
+        self.runtime = SimpleNamespace(infrastructure=SimpleNamespace(sender=self.sender))
+
+    def test_schedules_recall_on_single_worker(self) -> None:
+        import time
+        import app.services.safety.message_recall_scheduler as module
+
+        config = {"enabled": True, "delay": 0.01, "max_pending": 10, "exclude_commands": []}
+        with patch.object(module, "AUTO_RECALL_CONFIG", config):
+            service = module.MessageRecallScheduler(self.runtime)
+            try:
+                service.schedule_user_message_recall("msg-1", "channel-1", "area-1", "ts-1")
+                deadline = time.time() + 1.0
+                while time.time() < deadline and not self.sender.recall_message.called:
+                    time.sleep(0.01)
+
+                self.sender.recall_message.assert_called_once_with(
+                    message_id="msg-1",
+                    area="area-1",
+                    channel="channel-1",
+                    timestamp="ts-1",
+                )
+            finally:
+                service.stop()
+
+    def test_pending_limit_skips_extra_tasks(self) -> None:
+        import app.services.safety.message_recall_scheduler as module
+
+        config = {"enabled": True, "delay": 30, "max_pending": 1, "exclude_commands": []}
+        with patch.object(module, "AUTO_RECALL_CONFIG", config):
+            service = module.MessageRecallScheduler(self.runtime)
+            try:
+                service.schedule_user_message_recall("msg-1", "channel-1", "area-1")
+                service.schedule_user_message_recall("msg-2", "channel-1", "area-1")
+
+                self.assertEqual(service.cancel_all(), 1)
+                self.sender.recall_message.assert_not_called()
+            finally:
+                service.stop()
+
+
 class ModerationServiceTest(unittest.TestCase):
     def setUp(self) -> None:
         self.sender = Mock()


### PR DESCRIPTION
## 概述
将后台管理 UI 中散落的内联事件处理器（`onclick`/`onchange`/`onkeydown`）全量迁移到集中式事件委托架构，解耦行为与表现，提升可维护性、可扩展性与安全性。

## 主要改动
- **admin-shell.js**：新增全局动作注册表 `_actionHandlers` 与 `AdminShell.registerActions`，在 `document` 级委托 `click`（`data-action`）、`change`（`data-change`）、`keydown`（`data-enter`，仅回车）事件；内置 `close-modal`/`login`/`logout` 动作。
- **shared.py**：顶栏按钮从硬编码 HTML 字符串改为结构化声明 + `_render_topbar_actions` 渲染，统一走 `data-action` 委托。
- **全部 11 个页面**（content.html + script.js）：内联事件处理器替换为 `data-action`/`data-change`/`data-enter`，页面脚本通过 `registerActions` 注册处理函数；动态生成的属性值统一用 `AdminShell.escapeHtml` 转义，防止 XSS。
- 缓存刷新版本号递增至 `v=12`。

## 验证
- 全站审查：除图片 `onerror` 外无任何残留内联事件处理器。
- 所有 `data-*` 动作键与注册处理函数一一对应，无缺失/重复。
- JS / Python lint 通过。

## 测试计划
- [ ] 登录/登出、弹窗关闭
- [ ] 各页顶栏按钮与动态列表按钮（成员、频道、计划任务、插件等）
- [ ] select/checkbox 的 change 行为与搜索框回车
