### PR TITLE
重构：mention/slash 路由共用 handle_pick 与 clear_ai_memory

### DIFF
--- a/src/app/services/routing/builtin_command_actions.py
+++ b/src/app/services/routing/builtin_command_actions.py
@@ -40,6 +40,7 @@ class CommunityCommandActions:
 class InteractionCommandActions:
     def __init__(self, runtime: CommandRuntimeView):
         self._services = runtime.services
+        self._sender = sender_of(runtime)
 
     def show_voice_channels(self, channel: str, area: str) -> None:
         self._services.interaction.common.show_voice_channels(channel, area)
@@ -61,6 +62,27 @@ class InteractionCommandActions:
 
     def generate_image(self, prompt: str, channel: str, area: str, user: str) -> None:
         self._services.interaction.common.generate_image(prompt, channel, area, user)
+
+    def clear_ai_memory(self, user: str, channel: str, area: str) -> None:
+        """清除用户在当前频道的 AI 对话记忆（mention/slash 共用）。"""
+        cleared = self._services.interaction.chat.clear_memory(user, channel)
+        if cleared:
+            self._sender.send_message("对话记忆已清除", channel=channel, area=area)
+        else:
+            self._sender.send_message("当前没有对话记忆", channel=channel, area=area)
+
+    def handle_pick(self, raw: str, channel: str, area: str, user: str, usage: str) -> None:
+        """选择候选编号：先试点歌候选，再试成员候选（mention/slash 共用）。"""
+        token = (raw or "").strip()
+        if not token.isdigit():
+            self._sender.send_message(usage, channel=channel, area=area)
+            return
+        index = int(token)
+        if self._services.interaction.music.handle_pick(index, channel, area, user):
+            return
+        if self._services.community.member.handle_pick(index, channel, area, user):
+            return
+        self._sender.send_message("当前没有可选择的候选结果，请先搜索或搜歌", channel=channel, area=area)
 
 
 class ModerationCommandActions:

--- a/src/app/services/routing/mention_command_router.py
+++ b/src/app/services/routing/mention_command_router.py
@@ -88,7 +88,7 @@ class MentionCommandRouter:
             # 定时消息为「1 slash 命令 : 5 mention 动词」形态不对称，mention 子动作别名保留字面量（另见 _raw_rules）
             (("定时消息列表", "定时消息"), lambda: self._actions.scheduler.list_scheduled(channel, area)),
             (mention_of("reminders_list"), lambda: self._actions.scheduler.list_reminders(channel, area, user)),
-            (mention_of("clear_ai_memory"), lambda: self._clear_ai_memory(user, channel, area)),
+            (mention_of("clear_ai_memory"), lambda: self._actions.interaction.clear_ai_memory(user, channel, area)),
         )
 
     def _arg_rules(self, channel: str, area: str, user: str):
@@ -156,29 +156,9 @@ class MentionCommandRouter:
             (("删除定时消息", "移除定时消息"), lambda raw: self._actions.scheduler.delete_scheduled(raw, channel, area)),
             (("开启定时消息", "启用定时消息"), lambda raw: self._actions.scheduler.toggle_scheduled(raw, channel, area, True)),
             (("关闭定时消息", "停用定时消息"), lambda raw: self._actions.scheduler.toggle_scheduled(raw, channel, area, False)),
-            (mention_of("pick"), lambda raw: self._handle_pick(raw, channel, area, user)),
+            (mention_of("pick"), lambda raw: self._actions.interaction.handle_pick(raw, channel, area, user, "用法: @bot 选择 <编号>")),
             (mention_of("songsearch"), lambda raw: self._services.interaction.music.search_candidates(raw, channel, area, user)),
         )
-
-    def _clear_ai_memory(self, user: str, channel: str, area: str) -> None:
-        """清除用户在当前频道的 AI 对话记忆。"""
-        cleared = self._services.interaction.chat.clear_memory(user, channel)
-        if cleared:
-            self._sender.send_message("对话记忆已清除", channel=channel, area=area)
-        else:
-            self._sender.send_message("当前没有对话记忆", channel=channel, area=area)
-
-    def _handle_pick(self, raw: str, channel: str, area: str, user: str) -> None:
-        token = (raw or "").strip()
-        if not token.isdigit():
-            self._sender.send_message("用法: @bot 选择 <编号>", channel=channel, area=area)
-            return
-        index = int(token)
-        if self._services.interaction.music.handle_pick(index, channel, area, user):
-            return
-        if self._services.community.member.handle_pick(index, channel, area, user):
-            return
-        self._sender.send_message("当前没有可选择的候选结果，请先搜索或搜歌", channel=channel, area=area)
 
     def _should_treat_as_unknown_command(self, text: str) -> bool:
         from app.services.interaction.help_catalog import suggest_command_usages

--- a/src/app/services/routing/slash_command_router.py
+++ b/src/app/services/routing/slash_command_router.py
@@ -109,7 +109,7 @@ class SlashCommandRouter:
             (slash_of("help"), lambda topic: self._actions.interaction.show_help(channel, area, self._current_user, topic), "用法: /help 音乐"),
             (slash_of("enter"), lambda channel_id: self._actions.interaction.enter_channel(channel_id, channel, area), "用法: /enter 频道ID"),
             (slash_of("songsearch"), lambda keyword: self._services.interaction.music.search_candidates(keyword, channel, area, self._current_user), "用法: /songsearch 关键词"),
-            (slash_of("pick"), lambda raw: self._handle_pick(raw, channel, area, self._current_user), "用法: /pick <编号>"),
+            (slash_of("pick"), lambda raw: self._actions.interaction.handle_pick(raw, channel, area, self._current_user, "用法: /pick <编号>"), "用法: /pick <编号>"),
         )
 
     def _pair_rules(self, channel: str, area: str):
@@ -220,11 +220,7 @@ class SlashCommandRouter:
             return
 
         if command in slash_of("clear_ai_memory"):
-            cleared = self._services.interaction.chat.clear_memory(user, channel)
-            if cleared:
-                self._sender.send_message("对话记忆已清除", channel=channel, area=area)
-            else:
-                self._sender.send_message("当前没有对话记忆", channel=channel, area=area)
+            self._actions.interaction.clear_ai_memory(user, channel, area)
             return
 
         self._services.interaction.chat.send_unknown_command(
@@ -233,15 +229,3 @@ class SlashCommandRouter:
             area,
             suggestions=self._services.interaction.help.suggest_commands(command),
         )
-
-    def _handle_pick(self, raw: str, channel: str, area: str, user: str) -> None:
-        token = (raw or "").strip()
-        if not token.isdigit():
-            self._sender.send_message("用法: /pick <编号>", channel=channel, area=area)
-            return
-        index = int(token)
-        if self._services.interaction.music.handle_pick(index, channel, area, user):
-            return
-        if self._services.community.member.handle_pick(index, channel, area, user):
-            return
-        self._sender.send_message("当前没有可选择的候选结果，请先搜索或搜歌", channel=channel, area=area)


### PR DESCRIPTION
## 概述

把两个 router 里逐字重复的 _handle_pick / _clear_ai_memory 上移到共享的 InteractionCommandActions。

## 说明
- 别名分组仍由命令注册表派生，golden 测试（_exact_rules/_arg_rules 等）不变。
- 行为保持，本地全套 212 测试通过（0 跳过）。