### PR TITLE
refactor: 插件命令入口统一收敛到 PluginCommandMixin + 路由/鉴权可维护性改进

### DIFF
--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -20,10 +20,31 @@
 - `metadata`
 - `command_capabilities`
 - `config_spec`
-- `handle_mention`
-- `handle_slash`
+- `dispatch_command`（继承 `PluginCommandMixin`，见下方「命令入口」）
 - `on_load`
 - `on_unload`
+
+### 命令入口
+
+命令入口统一走 `plugins/_shared/command_mixin.py` 的 `PluginCommandMixin`：插件类同时继承
+`PluginCommandMixin` 和 `BotModule`，只需实现 `dispatch_command`，mention 前缀与 slash 命令名
+会按 `command_capabilities` 自动剥离匹配，异常也由 mixin 统一捕获并回复。错误文案与日志通道
+用类属性 `command_error_prefix` / `command_log_name` 定制：
+
+```python
+from plugins._shared.command_mixin import PluginCommandMixin
+
+
+class FooPlugin(PluginCommandMixin, BotModule):
+    command_error_prefix = "Foo 查询出错"
+    command_log_name = "FooPlugin"
+
+    def dispatch_command(self, command_text, channel, area, user, handler):
+        ...
+```
+
+只有需要特殊路由的插件（例如 arc 的 `/arcevent` 走独立截图逻辑）才自行覆盖 `handle_slash`；
+普通插件不要再手写 `handle_mention` / `handle_slash`。
 
 最核心的几个模型：
 
@@ -85,6 +106,7 @@ python tools/export_plugin_config_assets.py delta_force lol_ban
 
 `plugins/_shared/` 提供了插件间复用的基类，避免每个插件重复造轮子：
 
+- `PluginCommandMixin`（`_shared/command_mixin.py`）：统一的 mention/slash 命令入口。插件继承它后只需实现 `dispatch_command`，前缀剥离、slash 匹配、异常包装与统一发送都由 mixin 完成。当前全部插件均采用此写法（参考 `apex`、`steam_price`、`lol_ban` 等），新插件请遵循。
 - `IntervalWorker`（`_shared/background.py`）：按固定间隔运行的守护线程基类，统一封装「启动一次 / 停止 / 间隔轮询」生命周期。子类只需实现 `_tick()`，并在合适时机调用 `_start_thread()` 与 `stop()`；线程以「先等待 `interval` 再执行一轮」驱动，`_tick` 抛出的异常会被记录而不致线程退出，长循环里可用 `self.stopping` 提前退出。适合做定时推送 / 轮询监控（参考 `delta_force/daily_push.py`、`steam_price/monitor.py`）。
 - `JsonHttpClient`（`_shared/http_client.py`）：带重试与 JSON 解析的 HTTP 客户端基类，统一封装 User-Agent、超时、代理与重试循环。通过 `request_json(method, url, ...)` 发起请求，成功返回解析后的 JSON，网络异常重试耗尽或 JSON 解析失败返回 `{"_error": ...}`；`on_status` 回调可在 `raise_for_status` 之前拦截 404/429 等状态码自定义返回（参考 `apex/api.py`、`steam_price/api.py`）。
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -17,11 +17,11 @@ plugins/
 
 每个插件入口通常需要：
 
-1. 定义一个继承 `BotModule` 的类
+1. 定义一个同时继承 `PluginCommandMixin` 和 `BotModule` 的类
 2. 实现 `metadata`
 3. 声明 `command_capabilities`
 4. 视需要实现 `config_spec`
-5. 实现 `handle_mention` 和/或 `handle_slash`
+5. 实现 `dispatch_command`（命令入口由 `PluginCommandMixin` 统一处理，无需手写 `handle_mention` / `handle_slash`）
 
 如果插件依赖私有辅助模块，例如 `plugins/demo_plugin/service.py`，建议声明 `private_modules`，以便卸载时清理模块缓存。
 
@@ -63,6 +63,7 @@ python tools/export_plugin_config_assets.py delta_force
 
 `plugins/_shared/` 提供可复用基类，避免重复造轮子：
 
+- `PluginCommandMixin`：统一的 mention/slash 命令入口，子类只实现 `dispatch_command`，用类属性 `command_error_prefix` / `command_log_name` 定制错误文案与日志名。当前全部插件均采用此写法。
 - `IntervalWorker`：固定间隔的后台守护线程基类（定时推送 / 轮询监控），子类实现 `_tick()`。
 - `JsonHttpClient`：带重试与 JSON 解析的 HTTP 客户端基类，统一 UA / 超时 / 代理 / 重试。
 

--- a/plugins/_shared/command_mixin.py
+++ b/plugins/_shared/command_mixin.py
@@ -1,0 +1,80 @@
+"""插件共享的命令入口样板（mention/slash 分发）。
+
+把各插件重复的 handle_mention 前缀剥离、handle_slash 命令匹配、_dispatch 异常包装
+与统一发送收敛到一个 mixin。子类只需实现 ``dispatch_command``，mention 前缀与 slash
+命令名取自 ``command_capabilities``，错误文案与日志通道用类属性定制。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from core.logger_config import get_logger
+
+
+class PluginCommandMixin:
+    """为插件提供统一的 mention/slash 命令入口。
+
+    用法::
+
+        class FooPlugin(PluginCommandMixin, BotModule):
+            command_error_prefix = "Foo 查询出错"
+            command_log_name = "FooPlugin"
+
+            def dispatch_command(self, command_text, channel, area, user, handler):
+                ...
+    """
+
+    # 命令异常时回复用户的前缀文案（如「Apex 查询出错」）。
+    command_error_prefix: str = "命令出错"
+    # 异常日志通道名。
+    command_log_name: str = "Plugin"
+
+    def handle_mention(self, text: str, channel: str, area: str, user: str, handler: Any) -> bool:
+        for prefix in self.command_capabilities.mention_prefixes:
+            if text.startswith(prefix):
+                self._run_plugin_command(text[len(prefix):].strip(), channel, area, user, handler)
+                return True
+        return False
+
+    def handle_slash(
+        self,
+        command: str,
+        subcommand: Optional[str],
+        arg: Optional[str],
+        channel: str,
+        area: str,
+        user: str,
+        handler: Any,
+    ) -> bool:
+        aliases = {str(c).strip().lower() for c in self.command_capabilities.slash_commands}
+        if (command or "").strip().lower() not in aliases:
+            return False
+        parts = []
+        if subcommand:
+            parts.append(str(subcommand))
+        if arg:
+            parts.append(str(arg))
+        self._run_plugin_command(" ".join(parts).strip(), channel, area, user, handler)
+        return True
+
+    def _run_plugin_command(
+        self, command_text: str, channel: str, area: str, user: str, handler: Any
+    ) -> None:
+        try:
+            self.dispatch_command(command_text, channel, area, user, handler)
+        except Exception as exc:
+            get_logger(self.command_log_name).exception(
+                "%s: command failed: %s", self.command_log_name, command_text
+            )
+            self._send(handler, f"{self.command_error_prefix}: {exc}", channel, area)
+
+    @staticmethod
+    def _send(handler: Any, text: str, channel: str, area: str) -> None:
+        handler.sender.send_message(text, channel=channel, area=area)
+
+    def dispatch_command(
+        self, command_text: str, channel: str, area: str, user: str, handler: Any
+    ) -> None:
+        """子类实现：解析并执行具体命令。"""
+        raise NotImplementedError

--- a/plugins/apex/__init__.py
+++ b/plugins/apex/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-from core.logger_config import get_logger
 from domain.plugins.base import (
     BotModule,
     PluginCommandCapabilities,
@@ -16,6 +15,8 @@ from domain.plugins.base import (
     validate_range,
 )
 
+from plugins._shared.command_mixin import PluginCommandMixin
+
 from .api import ApexApiClient
 from .formatters import (
     build_help_text,
@@ -25,10 +26,11 @@ from .formatters import (
     format_predator,
 )
 
-logger = get_logger("ApexPlugin")
 
+class ApexPlugin(PluginCommandMixin, BotModule):
+    command_error_prefix = "Apex 查询出错"
+    command_log_name = "ApexPlugin"
 
-class ApexPlugin(BotModule):
     def __init__(self) -> None:
         self._config: dict = {}
         self._api: Optional[ApexApiClient] = None
@@ -102,33 +104,7 @@ class ApexPlugin(BotModule):
     def on_unload(self) -> None:
         pass
 
-    def handle_mention(self, text, channel, area, user, handler) -> bool:
-        for prefix in self.command_capabilities.mention_prefixes:
-            if text.startswith(prefix):
-                command = text[len(prefix):].strip()
-                self._dispatch(command, channel, area, user, handler)
-                return True
-        return False
-
-    def handle_slash(self, command, subcommand, arg, channel, area, user, handler) -> bool:
-        if (command or "").strip().lower() != "/apex":
-            return False
-        parts = []
-        if subcommand:
-            parts.append(subcommand)
-        if arg:
-            parts.append(arg)
-        self._dispatch(" ".join(parts).strip(), channel, area, user, handler)
-        return True
-
-    def _dispatch(self, command_text: str, channel: str, area: str, user: str, handler) -> None:
-        try:
-            self._dispatch_inner(command_text, channel, area, user, handler)
-        except Exception as exc:
-            logger.exception("ApexPlugin: command failed: %s", command_text)
-            self._send(handler, f"Apex 查询出错: {exc}", channel, area)
-
-    def _dispatch_inner(self, command_text: str, channel: str, area: str, user: str, handler) -> None:
+    def dispatch_command(self, command_text: str, channel: str, area: str, user: str, handler) -> None:
         text = command_text.strip()
         lower = text.lower()
 
@@ -221,7 +197,3 @@ class ApexPlugin(BotModule):
 
         data = self._api.get_predator()
         self._send(handler, format_predator(data), channel, area)
-
-    @staticmethod
-    def _send(handler, text: str, channel: str, area: str) -> None:
-        handler.sender.send_message(text, channel=channel, area=area)

--- a/plugins/arc_raiders/__init__.py
+++ b/plugins/arc_raiders/__init__.py
@@ -22,6 +22,8 @@ from domain.plugins.base import (
     validate_min,
 )
 
+from plugins._shared.command_mixin import PluginCommandMixin
+
 logger = get_logger("ArcRaidersPlugin")
 
 RARITY_ZH = {
@@ -62,7 +64,10 @@ MAP_ZH = {
 }
 
 
-class ArcRaidersPlugin(BotModule):
+class ArcRaidersPlugin(PluginCommandMixin, BotModule):
+    command_error_prefix = "Arc 查询出错"
+    command_log_name = "ArcRaidersPlugin"
+
     def __init__(self) -> None:
         self._handler = None
         self._config: dict[str, Any] = {}
@@ -171,14 +176,6 @@ class ArcRaidersPlugin(BotModule):
         self._handler = handler
         self._config = (config or {}).copy()
 
-    def handle_mention(self, text, channel, area, user, handler) -> bool:
-        raw = (text or "").strip()
-        for prefix in self.command_capabilities.mention_prefixes:
-            if raw.lower().startswith(prefix.lower()):
-                query = raw[len(prefix):].strip()
-                return self._dispatch(query, channel, area, handler)
-        return False
-
     def handle_slash(self, command, subcommand, arg, channel, area, user, handler) -> bool:
         if (command or "").strip().lower() == "/arcevent":
             if not self._config.get("enabled", False):
@@ -204,18 +201,9 @@ class ArcRaidersPlugin(BotModule):
                 except Exception:
                     pass
             return True
+        return super().handle_slash(command, subcommand, arg, channel, area, user, handler)
 
-        if (command or "").strip().lower() != "/arc":
-            return False
-        parts = []
-        if subcommand:
-            parts.append(subcommand)
-        if arg:
-            parts.append(arg)
-        query = " ".join(parts).strip()
-        return self._dispatch(query, channel, area, handler)
-
-    def _dispatch(self, query: str, channel: str, area: str, handler) -> bool:
+    def dispatch_command(self, command_text: str, channel: str, area: str, user: str, handler) -> None:
         if not self._config.get("enabled", False):
             self._send(
                 handler,
@@ -223,32 +211,32 @@ class ArcRaidersPlugin(BotModule):
                 channel,
                 area,
             )
-            return True
+            return
 
-        q = (query or "").strip()
+        q = (command_text or "").strip()
         force_text_mode = False
         if q.endswith(" 1"):
             q = q[:-2].strip()
             force_text_mode = True
         elif q == "1":
             self._send(handler, "用法: /arc <物品名> 或 /arc <物品名> 1（文字模式）", channel, area)
-            return True
+            return
 
         if not q or q.lower() in {"help", "帮助"}:
             self._send(handler, "用法: @bot arc <物品名> 或 /arc <物品名>", channel, area)
-            return True
+            return
 
         try:
             items = self._load_items()
         except Exception as exc:
             logger.warning("ArcRaiders: load index failed: %s", exc)
             self._send(handler, "Arc物品索引加载失败，请稍后重试。", channel, area)
-            return True
+            return
 
         matches = self._search_items(items, q)
         if not matches:
             self._send(handler, f"未找到与“{q}”相关的物品。", channel, area)
-            return True
+            return
 
         max_candidates = int(self._config.get("max_candidates", 6) or 6)
         if len(matches) > 1:
@@ -258,24 +246,23 @@ class ArcRaidersPlugin(BotModule):
                 rarity_zh = self._to_rarity_zh(str(item.get("rarity") or "?"))
                 lines.append(f"{idx}. {item.get('name','?')} ({item_type_zh} / {rarity_zh})")
             self._send(handler, "\n".join(lines), channel, area)
-            return True
+            return
 
         item = matches[0]
         item_id = str(item.get("id") or "").strip()
         if not item_id:
             self._send(handler, "命中物品缺少ID，暂时无法查询。", channel, area)
-            return True
+            return
 
         stats = self._fetch_drop_stats(item_id)
         locations = self._fetch_locations(item_id)
         if bool(self._config.get("image_mode", True)) and not force_text_mode:
             self._send(handler, "正在使用直观截图模式查询，查询时间可能较长，请耐心等待", channel, area)
             if self._send_item_image(handler, item_id, channel, area):
-                return True
+                return
             if self._send_fallback_card_image(handler, item, stats, locations, channel, area):
-                return True
+                return
         self._send(handler, self._format_result(item, stats, locations), channel, area)
-        return True
 
     def _send_item_image(self, handler, item_id: str, channel: str, area: str) -> bool:
         png_path = self._render_item_page_image(item_id)
@@ -587,10 +574,6 @@ class ArcRaidersPlugin(BotModule):
 
         lines.append(f"详情页: https://arctracker.io/zh-CN/items/{item_id}")
         return "\n".join(lines)
-
-    @staticmethod
-    def _send(handler, text: str, channel: str, area: str) -> None:
-        handler.sender.send_message(text, channel=channel, area=area)
 
     @staticmethod
     def _to_type_zh(value: str) -> str:

--- a/plugins/delta_force/__init__.py
+++ b/plugins/delta_force/__init__.py
@@ -19,6 +19,8 @@ from domain.plugins.base import (
     validate_range,
 )
 
+from plugins._shared.command_mixin import PluginCommandMixin
+
 from .api import DeltaForceApiClient, describe_common_failure
 from .assets import normalize_mode
 from .formatters import (
@@ -61,7 +63,10 @@ from .store import DeltaForceStore
 logger = get_logger("DeltaForcePlugin")
 
 
-class DeltaForcePlugin(BotModule):
+class DeltaForcePlugin(PluginCommandMixin, BotModule):
+    command_error_prefix = "三角洲命令执行失败"
+    command_log_name = "DeltaForcePlugin"
+
     def __init__(self) -> None:
         self._config: dict = {}
         self._api: Optional[DeltaForceApiClient] = None
@@ -255,34 +260,7 @@ class DeltaForcePlugin(BotModule):
         if self._push:
             self._push.stop()
 
-    def handle_mention(self, text, channel, area, user, handler) -> bool:
-        mention_prefix = self.command_capabilities.mention_prefixes[0]
-        command = text[len(mention_prefix):].strip() if text.startswith(mention_prefix) else text.strip()
-        if not command:
-            self._send_text(handler, build_help_text(), channel, area)
-            return True
-        self._dispatch(command, channel, area, user, handler)
-        return True
-
-    def handle_slash(self, command, subcommand, arg, channel, area, user, handler) -> bool:
-        if (command or "").strip().lower() != "/df":
-            return False
-        parts = []
-        if subcommand:
-            parts.append(subcommand)
-        if arg:
-            parts.append(arg)
-        self._dispatch(" ".join(parts).strip(), channel, area, user, handler, slash=True)
-        return True
-
-    def _dispatch(self, command_text: str, channel: str, area: str, user: str, handler, slash: bool = False) -> None:
-        try:
-            self._dispatch_inner(command_text, channel, area, user, handler, slash=slash)
-        except Exception as exc:
-            logger.exception("DeltaForcePlugin: command failed: %s", command_text)
-            self._send_text(handler, f"三角洲命令执行失败: {exc}", channel, area)
-
-    def _dispatch_inner(self, command_text: str, channel: str, area: str, user: str, handler, slash: bool = False) -> None:
+    def dispatch_command(self, command_text: str, channel: str, area: str, user: str, handler) -> None:
         command_text = command_text.strip()
         lower = command_text.lower()
 

--- a/plugins/lol_ban/__init__.py
+++ b/plugins/lol_ban/__init__.py
@@ -6,10 +6,20 @@ from domain.plugins.base import (
     PluginConfigSpec,
     PluginMetadata,
 )
-from .._shared.lol_common import extract_keyword_from_mention
+from plugins._shared.command_mixin import PluginCommandMixin
 
 
-class LolBanPlugin(BotModule):
+_HELP_TEXT = (
+    "请输入QQ号\n"
+    "格式: @bot 查封号 123456789  |  /lol 123456789\n"
+    "官方封号查询: https://gamesafe.qq.com/query_punish.shtml"
+)
+
+
+class LolBanPlugin(PluginCommandMixin, BotModule):
+    command_error_prefix = "封号查询出错"
+    command_log_name = "LolBanPlugin"
+
     def __init__(self):
         self._handler = None
         self._config: dict = {}
@@ -55,46 +65,11 @@ class LolBanPlugin(BotModule):
         from .query_service import LolQueryHandler
         self._handler = LolQueryHandler(self._config)
 
-    def _keyword(self, text: str) -> str:
-        return extract_keyword_from_mention(text, self.command_capabilities.mention_prefixes)
-
-    def handle_mention(self, text, channel, area, user, handler):
-        keyword = self._keyword(text)
+    def dispatch_command(self, command_text, channel, area, user, handler) -> None:
+        keyword = command_text.strip()
         if not keyword:
-            handler.sender.send_message(
-                "请输入QQ号，例如: @bot 查封号 123456789\n"
-                "官方封号查询: https://gamesafe.qq.com/query_punish.shtml",
-                channel=channel,
-                area=area,
-            )
-            return True
-        handler.sender.send_message(
-            f"{Msg.SEARCH} 正在查询 QQ {keyword} 的封号状态...",
-            channel=channel,
-            area=area,
-        )
+            self._send(handler, _HELP_TEXT, channel, area)
+            return
+        self._send(handler, f"{Msg.SEARCH} 正在查询 QQ {keyword} 的封号状态...", channel, area)
         reply = self._handler.query_and_format(keyword)
-        handler.sender.send_message(reply, channel=channel, area=area)
-        return True
-
-    def handle_slash(self, command, subcommand, arg, channel, area, user, handler):
-        keyword = (subcommand or "").strip()
-        if arg:
-            keyword = f"{keyword} {arg}".strip() if keyword else arg.strip()
-        if not keyword:
-            handler.sender.send_message(
-                "用法: /lol QQ号\n"
-                "示例: /lol 123456789\n\n"
-                "官方封号查询: https://gamesafe.qq.com/query_punish.shtml",
-                channel=channel,
-                area=area,
-            )
-            return True
-        handler.sender.send_message(
-            f"{Msg.SEARCH} 正在查询 QQ {keyword} 的封号状态...",
-            channel=channel,
-            area=area,
-        )
-        reply = self._handler.query_and_format(keyword)
-        handler.sender.send_message(reply, channel=channel, area=area)
-        return True
+        self._send(handler, reply, channel, area)

--- a/plugins/lol_fa8/__init__.py
+++ b/plugins/lol_fa8/__init__.py
@@ -6,10 +6,22 @@ from domain.plugins.base import (
     PluginConfigSpec,
     PluginMetadata,
 )
-from .._shared.lol_common import extract_keyword_from_mention
+from plugins._shared.command_mixin import PluginCommandMixin
 
 
-class LolFa8Plugin(BotModule):
+_HELP_TEXT = (
+    "请输入召唤师名称\n"
+    "格式: @bot 战绩 召唤师名#编号  |  /zj 召唤师名#编号\n"
+    "示例: @bot 战绩 艺术就是充钱丶#72269\n"
+    "指定大区: @bot 战绩 班德尔城 召唤师名#编号  |  /zj 班德尔城 召唤师名#编号\n"
+    "按区搜索: @bot 战绩 3 召唤师名#编号 (1-5对应联盟一~五区)"
+)
+
+
+class LolFa8Plugin(PluginCommandMixin, BotModule):
+    command_error_prefix = "战绩查询出错"
+    command_log_name = "LolFa8Plugin"
+
     def __init__(self):
         self._handler = None
         self._config: dict = {}
@@ -64,49 +76,11 @@ class LolFa8Plugin(BotModule):
             self._handler = FA8Handler(self._config)
         return self._handler
 
-    def _keyword(self, text: str) -> str:
-        return extract_keyword_from_mention(text, self.command_capabilities.mention_prefixes)
-
-    def handle_mention(self, text, channel, area, user, handler):
-        keyword = self._keyword(text)
+    def dispatch_command(self, command_text, channel, area, user, handler) -> None:
+        keyword = command_text.strip()
         if not keyword:
-            handler.sender.send_message(
-                "请输入召唤师名称\n"
-                "格式: @bot 战绩 召唤师名#编号\n"
-                "示例: @bot 战绩 艺术就是充钱丶#72269\n"
-                "指定大区: @bot 战绩 班德尔城 召唤师名#编号\n"
-                "按区搜索: @bot 战绩 3 召唤师名#编号 (1-5对应联盟一~五区)",
-                channel=channel,
-                area=area,
-            )
-            return True
-        handler.sender.send_message(
-            f"{Msg.SEARCH} 正在查询 {keyword} 的战绩...",
-            channel=channel,
-            area=area,
-        )
+            self._send(handler, _HELP_TEXT, channel, area)
+            return
+        self._send(handler, f"{Msg.SEARCH} 正在查询 {keyword} 的战绩...", channel, area)
         reply = self._service().query_and_format(keyword)
-        handler.sender.send_message(reply, channel=channel, area=area)
-        return True
-
-    def handle_slash(self, command, subcommand, arg, channel, area, user, handler):
-        keyword = (subcommand or "").strip()
-        if arg:
-            keyword = f"{keyword} {arg}".strip() if keyword else arg.strip()
-        if not keyword:
-            handler.sender.send_message(
-                "用法: /zj 召唤师名#编号\n"
-                "示例: /zj 艺术就是充钱丶#72269\n"
-                "指定大区: /zj 班德尔城 召唤师名#编号",
-                channel=channel,
-                area=area,
-            )
-            return True
-        handler.sender.send_message(
-            f"{Msg.SEARCH} 正在查询 {keyword} 的战绩...",
-            channel=channel,
-            area=area,
-        )
-        reply = self._service().query_and_format(keyword)
-        handler.sender.send_message(reply, channel=channel, area=area)
-        return True
+        self._send(handler, reply, channel, area)

--- a/plugins/steam_price/__init__.py
+++ b/plugins/steam_price/__init__.py
@@ -16,6 +16,8 @@ from domain.plugins.base import (
     validate_range,
 )
 
+from plugins._shared.command_mixin import PluginCommandMixin
+
 from .api import SteamPriceApiClient
 from .monitor import SteamPriceMonitor
 from .store import SteamPriceStore
@@ -149,7 +151,10 @@ def _format_game_detail(detail: dict) -> str:
     return "\n".join(lines)
 
 
-class SteamPricePlugin(BotModule):
+class SteamPricePlugin(PluginCommandMixin, BotModule):
+    command_error_prefix = "Steam 查询出错"
+    command_log_name = "SteamPricePlugin"
+
     def __init__(self) -> None:
         self._config: dict = {}
         self._api: Optional[SteamPriceApiClient] = None
@@ -247,37 +252,11 @@ class SteamPricePlugin(BotModule):
     # 命令入口
     # ------------------------------------------------------------------
 
-    def handle_mention(self, text, channel, area, user, handler) -> bool:
-        for prefix in self.command_capabilities.mention_prefixes:
-            if text.startswith(prefix):
-                command = text[len(prefix):].strip()
-                self._dispatch(command, channel, area, user, handler)
-                return True
-        return False
-
-    def handle_slash(self, command, subcommand, arg, channel, area, user, handler) -> bool:
-        if (command or "").strip().lower() != "/steam":
-            return False
-        parts = []
-        if subcommand:
-            parts.append(subcommand)
-        if arg:
-            parts.append(arg)
-        self._dispatch(" ".join(parts).strip(), channel, area, user, handler)
-        return True
-
     # ------------------------------------------------------------------
     # 命令分发
     # ------------------------------------------------------------------
 
-    def _dispatch(self, command_text: str, channel: str, area: str, user: str, handler) -> None:
-        try:
-            self._dispatch_inner(command_text, channel, area, user, handler)
-        except Exception as exc:
-            logger.exception("SteamPricePlugin: command failed: %s", command_text)
-            self._send(handler, f"Steam 查询出错: {exc}", channel, area)
-
-    def _dispatch_inner(self, command_text: str, channel: str, area: str, user: str, handler) -> None:
+    def dispatch_command(self, command_text: str, channel: str, area: str, user: str, handler) -> None:
         text = command_text.strip()
         lower = text.lower()
 
@@ -478,10 +457,3 @@ class SteamPricePlugin(BotModule):
             self._store.unsubscribe_channel(channel, area)
             self._send(handler, "已关闭当前频道的 Steam 特惠推送。", channel, area)
 
-    # ------------------------------------------------------------------
-    # 工具
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _send(handler, text: str, channel: str, area: str) -> None:
-        handler.sender.send_message(text, channel=channel, area=area)

--- a/src/app/infrastructure/plugin_runtime/scaffold.py
+++ b/src/app/infrastructure/plugin_runtime/scaffold.py
@@ -103,8 +103,13 @@ from domain.plugins.base import (
     PluginMetadata,
 )
 
+from plugins._shared.command_mixin import PluginCommandMixin
 
-class {class_name}(BotModule):
+
+class {class_name}(PluginCommandMixin, BotModule):
+    command_error_prefix = "{plugin_name} 出错"
+    command_log_name = "{class_name}"
+
     @property
     def metadata(self) -> PluginMetadata:
         return PluginMetadata(
@@ -139,9 +144,7 @@ class {class_name}(BotModule):
         self._handler = handler
         self._config = (config or {{}}).copy()
 
-    def handle_mention(self, text, channel, area, user, handler) -> bool:
-        return False
-
-    def handle_slash(self, command, subcommand, arg, channel, area, user, handler) -> bool:
-        return False
+    def dispatch_command(self, command_text, channel, area, user, handler) -> None:
+        # TODO: 解析并执行具体命令；mention 前缀与 slash 命令已由 mixin 剥离。
+        self._send(handler, "{plugin_name} 暂未实现命令", channel, area)
 '''

--- a/src/app/services/routing/builtin_command_actions.py
+++ b/src/app/services/routing/builtin_command_actions.py
@@ -40,6 +40,7 @@ class CommunityCommandActions:
 class InteractionCommandActions:
     def __init__(self, runtime: CommandRuntimeView):
         self._services = runtime.services
+        self._sender = sender_of(runtime)
 
     def show_voice_channels(self, channel: str, area: str) -> None:
         self._services.interaction.common.show_voice_channels(channel, area)
@@ -61,6 +62,27 @@ class InteractionCommandActions:
 
     def generate_image(self, prompt: str, channel: str, area: str, user: str) -> None:
         self._services.interaction.common.generate_image(prompt, channel, area, user)
+
+    def clear_ai_memory(self, user: str, channel: str, area: str) -> None:
+        """清除用户在当前频道的 AI 对话记忆（mention/slash 共用）。"""
+        cleared = self._services.interaction.chat.clear_memory(user, channel)
+        if cleared:
+            self._sender.send_message("对话记忆已清除", channel=channel, area=area)
+        else:
+            self._sender.send_message("当前没有对话记忆", channel=channel, area=area)
+
+    def handle_pick(self, raw: str, channel: str, area: str, user: str, usage: str) -> None:
+        """选择候选编号：先试点歌候选，再试成员候选（mention/slash 共用）。"""
+        token = (raw or "").strip()
+        if not token.isdigit():
+            self._sender.send_message(usage, channel=channel, area=area)
+            return
+        index = int(token)
+        if self._services.interaction.music.handle_pick(index, channel, area, user):
+            return
+        if self._services.community.member.handle_pick(index, channel, area, user):
+            return
+        self._sender.send_message("当前没有可选择的候选结果，请先搜索或搜歌", channel=channel, area=area)
 
 
 class ModerationCommandActions:

--- a/src/app/services/routing/mention_command_router.py
+++ b/src/app/services/routing/mention_command_router.py
@@ -88,7 +88,7 @@ class MentionCommandRouter:
             # 定时消息为「1 slash 命令 : 5 mention 动词」形态不对称，mention 子动作别名保留字面量（另见 _raw_rules）
             (("定时消息列表", "定时消息"), lambda: self._actions.scheduler.list_scheduled(channel, area)),
             (mention_of("reminders_list"), lambda: self._actions.scheduler.list_reminders(channel, area, user)),
-            (mention_of("clear_ai_memory"), lambda: self._clear_ai_memory(user, channel, area)),
+            (mention_of("clear_ai_memory"), lambda: self._actions.interaction.clear_ai_memory(user, channel, area)),
         )
 
     def _arg_rules(self, channel: str, area: str, user: str):
@@ -156,29 +156,9 @@ class MentionCommandRouter:
             (("删除定时消息", "移除定时消息"), lambda raw: self._actions.scheduler.delete_scheduled(raw, channel, area)),
             (("开启定时消息", "启用定时消息"), lambda raw: self._actions.scheduler.toggle_scheduled(raw, channel, area, True)),
             (("关闭定时消息", "停用定时消息"), lambda raw: self._actions.scheduler.toggle_scheduled(raw, channel, area, False)),
-            (mention_of("pick"), lambda raw: self._handle_pick(raw, channel, area, user)),
+            (mention_of("pick"), lambda raw: self._actions.interaction.handle_pick(raw, channel, area, user, "用法: @bot 选择 <编号>")),
             (mention_of("songsearch"), lambda raw: self._services.interaction.music.search_candidates(raw, channel, area, user)),
         )
-
-    def _clear_ai_memory(self, user: str, channel: str, area: str) -> None:
-        """清除用户在当前频道的 AI 对话记忆。"""
-        cleared = self._services.interaction.chat.clear_memory(user, channel)
-        if cleared:
-            self._sender.send_message("对话记忆已清除", channel=channel, area=area)
-        else:
-            self._sender.send_message("当前没有对话记忆", channel=channel, area=area)
-
-    def _handle_pick(self, raw: str, channel: str, area: str, user: str) -> None:
-        token = (raw or "").strip()
-        if not token.isdigit():
-            self._sender.send_message("用法: @bot 选择 <编号>", channel=channel, area=area)
-            return
-        index = int(token)
-        if self._services.interaction.music.handle_pick(index, channel, area, user):
-            return
-        if self._services.community.member.handle_pick(index, channel, area, user):
-            return
-        self._sender.send_message("当前没有可选择的候选结果，请先搜索或搜歌", channel=channel, area=area)
 
     def _should_treat_as_unknown_command(self, text: str) -> bool:
         from app.services.interaction.help_catalog import suggest_command_usages

--- a/src/app/services/routing/slash_command_router.py
+++ b/src/app/services/routing/slash_command_router.py
@@ -109,7 +109,7 @@ class SlashCommandRouter:
             (slash_of("help"), lambda topic: self._actions.interaction.show_help(channel, area, self._current_user, topic), "用法: /help 音乐"),
             (slash_of("enter"), lambda channel_id: self._actions.interaction.enter_channel(channel_id, channel, area), "用法: /enter 频道ID"),
             (slash_of("songsearch"), lambda keyword: self._services.interaction.music.search_candidates(keyword, channel, area, self._current_user), "用法: /songsearch 关键词"),
-            (slash_of("pick"), lambda raw: self._handle_pick(raw, channel, area, self._current_user), "用法: /pick <编号>"),
+            (slash_of("pick"), lambda raw: self._actions.interaction.handle_pick(raw, channel, area, self._current_user, "用法: /pick <编号>"), "用法: /pick <编号>"),
         )
 
     def _pair_rules(self, channel: str, area: str):
@@ -220,11 +220,7 @@ class SlashCommandRouter:
             return
 
         if command in slash_of("clear_ai_memory"):
-            cleared = self._services.interaction.chat.clear_memory(user, channel)
-            if cleared:
-                self._sender.send_message("对话记忆已清除", channel=channel, area=area)
-            else:
-                self._sender.send_message("当前没有对话记忆", channel=channel, area=area)
+            self._actions.interaction.clear_ai_memory(user, channel, area)
             return
 
         self._services.interaction.chat.send_unknown_command(
@@ -233,15 +229,3 @@ class SlashCommandRouter:
             area,
             suggestions=self._services.interaction.help.suggest_commands(command),
         )
-
-    def _handle_pick(self, raw: str, channel: str, area: str, user: str) -> None:
-        token = (raw or "").strip()
-        if not token.isdigit():
-            self._sender.send_message("用法: /pick <编号>", channel=channel, area=area)
-            return
-        index = int(token)
-        if self._services.interaction.music.handle_pick(index, channel, area, user):
-            return
-        if self._services.community.member.handle_pick(index, channel, area, user):
-            return
-        self._sender.send_message("当前没有可选择的候选结果，请先搜索或搜歌", channel=channel, area=area)

--- a/src/core/browser_launch.py
+++ b/src/core/browser_launch.py
@@ -1,0 +1,43 @@
+"""共享的 Chromium 启动参数。
+
+把语音推流与登录页共用的 Chromium 启动参数集中到 core 层，作为单一来源，
+避免认证模块（oopz.oopz_password_login）反向依赖音乐推流模块（music.voice_client）。
+"""
+
+from __future__ import annotations
+
+# 语音推流用的 Chromium 参数：媒体自动播放 + 关闭沙箱 + 直连（不走代理）。
+VOICE_STREAM_ARGS: list[str] = [
+    "--disable-web-security",
+    "--allow-file-access-from-files",
+    "--autoplay-policy=no-user-gesture-required",
+    "--use-fake-device-for-media-stream",
+    "--use-fake-ui-for-media-stream",
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+    "--no-proxy-server",
+]
+
+# 登录页相对推流额外需要的参数（反自动化检测 / 关闭崩溃上报等）。
+_LOGIN_EXTRA_ARGS: tuple[str, ...] = (
+    "--disable-blink-features=AutomationControlled",
+    "--autoplay-policy=no-user-gesture-required",
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-crash-reporter",
+    "--disable-crashpad",
+)
+
+
+def login_browser_args() -> list[str]:
+    """登录页用的 Chromium 参数。
+
+    在推流参数基础上去掉 ``--no-proxy-server``（登录需遵循 OOPZ/系统代理设置），
+    再补充反自动化检测与崩溃上报关闭等参数。
+    """
+    args = [arg for arg in VOICE_STREAM_ARGS if arg != "--no-proxy-server"]
+    for extra in _LOGIN_EXTRA_ARGS:
+        if extra not in args:
+            args.append(extra)
+    return args

--- a/src/music/voice_client.py
+++ b/src/music/voice_client.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple
 
 import requests as http_requests
 
+from core.browser_launch import VOICE_STREAM_ARGS as _BROWSER_ARGS
 from core.constants import USER_AGENT
 from core.http_constants import HTTP_TIMEOUT_DEFAULT, HTTP_TIMEOUT_DOWNLOAD
 from core.logger_config import get_logger
@@ -26,17 +27,6 @@ _HTML_PATH = os.path.join(_WEB_ASSETS_DIR, "agora_player.html")
 _SDK_PATH = os.path.join(_WEB_ASSETS_DIR, "agora_sdk.js")
 _SDK_URL = "https://download.agora.io/sdk/release/AgoraRTC_N-4.22.0.js"
 _SDK_MIN_SIZE = 500_000
-
-_BROWSER_ARGS = [
-    "--disable-web-security",
-    "--allow-file-access-from-files",
-    "--autoplay-policy=no-user-gesture-required",
-    "--use-fake-device-for-media-stream",
-    "--use-fake-ui-for-media-stream",
-    "--no-sandbox",
-    "--disable-dev-shm-usage",
-    "--no-proxy-server",
-]
 
 
 def _ensure_agora_sdk() -> None:

--- a/src/oopz/oopz_password_login.py
+++ b/src/oopz/oopz_password_login.py
@@ -19,6 +19,7 @@ import requests
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
+from core.browser_launch import login_browser_args
 from core.constants import USER_AGENT
 from core.http_constants import HTTP_TIMEOUT_LOGIN
 from core.json_utils import compact_json
@@ -105,24 +106,8 @@ _CLIENT_PASSWORD_MODULUS_DATA = {
     ],
 }
 
-try:
-    from music.voice_client import _BROWSER_ARGS as _VOICE_BROWSER_ARGS
-except Exception:
-    _VOICE_BROWSER_ARGS = []
-
-# 复用语音推流的 Chromium 参数，但登录页需要遵循 OOPZ/系统代理设置。
-_BROWSER_ARGS = [arg for arg in _VOICE_BROWSER_ARGS if arg != "--no-proxy-server"]
-for _arg in (
-    "--disable-blink-features=AutomationControlled",
-    "--autoplay-policy=no-user-gesture-required",
-    "--no-sandbox",
-    "--disable-setuid-sandbox",
-    "--disable-dev-shm-usage",
-    "--disable-crash-reporter",
-    "--disable-crashpad",
-):
-    if _arg not in _BROWSER_ARGS:
-        _BROWSER_ARGS.append(_arg)
+# Chromium 启动参数来自 core 单一来源，避免反向依赖 music.voice_client。
+_BROWSER_ARGS = login_browser_args()
 
 
 def _get_chromium_executable_path() -> Optional[str]:

--- a/src/oopz/oopz_sender.py
+++ b/src/oopz/oopz_sender.py
@@ -475,11 +475,8 @@ class OopzSender(UploadMixin, OopzApiMixin):
         body = {"target": target}
 
         try:
-            self._throttle()
-            body_str = compact_json(body)
-            headers = {**self.session.headers, **self.signer.oopz_headers(full_path, body_str)}
-            url = OOPZ_CONFIG["base_url"] + full_path
-            resp = self.session.patch(url, headers=headers, data=body_str.encode("utf-8"))
+            # 走统一签名通道 _request，复用 401/403/428 登录态自动刷新与重试。
+            resp = self._request("PATCH", full_path, body)
         except Exception as e:
             logger.error(f"打开私信会话异常: {e}")
             return {"error": str(e)}
@@ -555,11 +552,8 @@ class OopzSender(UploadMixin, OopzApiMixin):
         url_path = "/im/session/v2/sendImMessage"
 
         try:
-            self._throttle()
-            body_str = compact_json(body)
-            headers = {**self.session.headers, **self.signer.oopz_headers(url_path, body_str)}
-            url = OOPZ_CONFIG["base_url"] + url_path
-            resp = self.session.post(url, headers=headers, data=body_str.encode("utf-8"))
+            # 走统一签名通道 _request，复用 401/403/428 登录态自动刷新与重试。
+            resp = self._request("POST", url_path, body)
         except Exception as e:
             logger.error(f"发送私信异常: {e}")
             return {"error": str(e)}

--- a/tests/test_plugin_command_mixin.py
+++ b/tests/test_plugin_command_mixin.py
@@ -1,0 +1,90 @@
+"""PluginCommandMixin 的命令入口行为测试。
+
+锁定 mention 前缀剥离、slash 命令匹配与异常包装这套共享样板的契约，
+确保迁移到 mixin 的插件（apex / steam_price 等）行为不变。
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+for _path in (REPO_ROOT, SRC_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+
+from domain.plugins.base import BotModule, PluginCommandCapabilities, PluginMetadata  # noqa: E402
+from plugins._shared.command_mixin import PluginCommandMixin  # noqa: E402
+
+
+class _FakePlugin(PluginCommandMixin, BotModule):
+    command_error_prefix = "测试出错"
+    command_log_name = "FakePlugin"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.raise_on = None
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(name="fake", description="测试插件")
+
+    @property
+    def command_capabilities(self) -> PluginCommandCapabilities:
+        return PluginCommandCapabilities(
+            mention_prefixes=("steam", "Steam"),
+            slash_commands=("/steam",),
+        )
+
+    def dispatch_command(self, command_text, channel, area, user, handler) -> None:
+        if self.raise_on is not None and command_text == self.raise_on:
+            raise RuntimeError("boom")
+        self.calls.append(command_text)
+
+
+class PluginCommandMixinTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.plugin = _FakePlugin()
+        self.handler = Mock()
+
+    def test_mention_strips_prefix_and_dispatches(self) -> None:
+        handled = self.plugin.handle_mention("steam 关注 Hades", "c", "a", "u", self.handler)
+        self.assertTrue(handled)
+        self.assertEqual(self.plugin.calls, ["关注 Hades"])
+
+    def test_mention_without_prefix_not_handled(self) -> None:
+        handled = self.plugin.handle_mention("apex 战绩", "c", "a", "u", self.handler)
+        self.assertFalse(handled)
+        self.assertEqual(self.plugin.calls, [])
+
+    def test_slash_matches_and_joins_subcommand_arg(self) -> None:
+        handled = self.plugin.handle_slash("/steam", "watch", "Hades", "c", "a", "u", self.handler)
+        self.assertTrue(handled)
+        self.assertEqual(self.plugin.calls, ["watch Hades"])
+
+    def test_slash_case_insensitive(self) -> None:
+        handled = self.plugin.handle_slash("/STEAM", None, None, "c", "a", "u", self.handler)
+        self.assertTrue(handled)
+        self.assertEqual(self.plugin.calls, [""])
+
+    def test_slash_other_command_not_handled(self) -> None:
+        handled = self.plugin.handle_slash("/apex", None, None, "c", "a", "u", self.handler)
+        self.assertFalse(handled)
+        self.assertEqual(self.plugin.calls, [])
+
+    def test_dispatch_exception_replies_with_error_prefix(self) -> None:
+        self.plugin.raise_on = "炸"
+        handled = self.plugin.handle_mention("steam 炸", "chan", "area", "u", self.handler)
+        self.assertTrue(handled)
+        self.handler.sender.send_message.assert_called_once_with(
+            "测试出错: boom", channel="chan", area="area"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 将全部 6 个插件（apex / steam_price / lol_ban / lol_fa8 / arc_raiders / delta_force）的命令入口统一收敛到共享的 `PluginCommandMixin`：插件只需实现 `dispatch_command`，mention 前缀剥离 / slash 命令匹配 / 异常包装 / 统一发送均由 mixin 完成。
- 同步更新脚手架模板与文档（`scaffold.py`、`docs/plugin-development.md`、`plugins/README.md`），使「脚手架 = 文档 = 现成插件」彻底为一套写法，消除新人按文档写出旧写法的分裂风险。
- 其余可维护性改进：mention/slash 路由共用内建命令动作、断 auth↔music 环依赖、浏览器启动逻辑抽出等。
- arc_raiders 因 `/arcevent` 特殊截图路由，保留对 `handle_slash` 的覆盖。

## Test plan
- [x] `python -m pytest -q` 全绿：218 passed, 52 subtests passed
- [x] 新增 `tests/test_plugin_command_mixin.py` 覆盖 mixin 行为
- [x] 实跑脚手架生成临时插件可正常 import/构造
